### PR TITLE
chore: use logger that prints to stderr

### DIFF
--- a/Sources/momento/TopicClient.swift
+++ b/Sources/momento/TopicClient.swift
@@ -16,7 +16,6 @@ public protocol TopicClientProtocol {
 }
 
 public class TopicClient: TopicClientProtocol {
-    private let logProvider: LogProvider
     private let pubsubClient: PubsubClientProtocol
     private let credentialProvider: CredentialProviderProtocol
     
@@ -25,9 +24,7 @@ public class TopicClient: TopicClientProtocol {
         configuration: TopicClientConfigurationProtocol,
         credentialProvider: CredentialProviderProtocol
     ) {
-        self.logProvider = LogProvider()
         LogProvider.setLogger(loggerFactory: configuration.loggerFactory)
-        
         self.credentialProvider = credentialProvider
         self.pubsubClient = PubsubClient(
             configuration: configuration,

--- a/Sources/momento/TopicClient.swift
+++ b/Sources/momento/TopicClient.swift
@@ -16,23 +16,20 @@ public protocol TopicClientProtocol {
 }
 
 public class TopicClient: TopicClientProtocol {
-    var logger: MomentoLoggerProtocol
+    private let logProvider: LogProvider
     private let pubsubClient: PubsubClientProtocol
     private let credentialProvider: CredentialProviderProtocol
     
     @available(macOS 10.15, *)
     public init(
         configuration: TopicClientConfigurationProtocol,
-        credentialProvider: CredentialProviderProtocol,
-        logger: MomentoLoggerProtocol = DefaultMomentoLogger(
-            loggerName: "swift-momento-logger",
-            level: DefaultMomentoLoggerLevel.info
-        )
+        credentialProvider: CredentialProviderProtocol
     ) {
-        self.logger = logger
+        self.logProvider = LogProvider()
+        LogProvider.setLogger(loggerFactory: configuration.loggerFactory)
+        
         self.credentialProvider = credentialProvider
         self.pubsubClient = PubsubClient(
-            logger: logger,
             configuration: configuration,
             credentialProvider: credentialProvider
         )

--- a/Sources/momento/config/logging/DefaultMomentoLogger.swift
+++ b/Sources/momento/config/logging/DefaultMomentoLogger.swift
@@ -39,7 +39,7 @@ public class DefaultMomentoLogger: MomentoLoggerProtocol {
     }
     
     private func outputMessage(level: String, msg: String) {
-        debugPrint("[\(self.getCurrentTime())] \(level) (Momento: \(loggerName): \(msg)")
+        fputs("[\(self.getCurrentTime())] \(level) (Momento: \(loggerName): \(msg)", stderr)
     }
     
     private func getCurrentTime() -> String {

--- a/Sources/momento/config/logging/LogProvider.swift
+++ b/Sources/momento/config/logging/LogProvider.swift
@@ -5,7 +5,7 @@ class LogProvider {
         self.momentoLoggerFactory = loggerFactory
     }
     
-    internal static func getLogger(name: String) -> MomentoLoggerProtocol {
+    public static func getLogger(name: String) -> MomentoLoggerProtocol {
         return self.momentoLoggerFactory.getLogger(loggerName: name)
     }
 }

--- a/Sources/momento/config/logging/LogProvider.swift
+++ b/Sources/momento/config/logging/LogProvider.swift
@@ -1,17 +1,11 @@
 class LogProvider {
-    internal static var momentoLoggerFactory: MomentoLoggerFactoryProtocol? = nil
+    internal static var momentoLoggerFactory: MomentoLoggerFactoryProtocol = DefaultMomentoLoggerFactory()
     
     internal static func setLogger(loggerFactory: MomentoLoggerFactoryProtocol) {
         self.momentoLoggerFactory = loggerFactory
     }
     
-    internal static func getLogger(name: String) throws -> MomentoLoggerProtocol {
-        if self.momentoLoggerFactory != nil {
-            return self.momentoLoggerFactory!.getLogger(loggerName: name)
-        } else {
-            throw FailedPreconditionError(
-                message: "Momento Logger Factory is not yet initialized"
-            )
-        }
+    internal static func getLogger(name: String) -> MomentoLoggerProtocol {
+        return self.momentoLoggerFactory.getLogger(loggerName: name)
     }
 }

--- a/Sources/momento/config/logging/LogProvider.swift
+++ b/Sources/momento/config/logging/LogProvider.swift
@@ -1,0 +1,17 @@
+class LogProvider {
+    internal static var momentoLoggerFactory: MomentoLoggerFactoryProtocol? = nil
+    
+    internal static func setLogger(loggerFactory: MomentoLoggerFactoryProtocol) {
+        self.momentoLoggerFactory = loggerFactory
+    }
+    
+    internal static func getLogger(name: String) throws -> MomentoLoggerProtocol {
+        if self.momentoLoggerFactory != nil {
+            return self.momentoLoggerFactory!.getLogger(loggerName: name)
+        } else {
+            throw FailedPreconditionError(
+                message: "Momento Logger Factory is not yet initialized"
+            )
+        }
+    }
+}

--- a/Sources/momento/internal/PubsubClient.swift
+++ b/Sources/momento/internal/PubsubClient.swift
@@ -163,7 +163,7 @@ class PubsubClient: PubsubClientProtocol {
         request.topic = topicName
         
         let result = self.client.subscribe(request)
-        return TopicSubscribeSuccess(subscription: result)
+        return TopicSubscribeSuccess(subscription: result, logger: self.logger)
     }
     
     func close() {

--- a/Sources/momento/internal/PubsubClient.swift
+++ b/Sources/momento/internal/PubsubClient.swift
@@ -76,11 +76,9 @@ class PubsubClient: PubsubClientProtocol {
     var client: CacheClient_Pubsub_PubsubAsyncClient
     
     init(
-        logger: MomentoLoggerProtocol,
         configuration: TopicClientConfigurationProtocol,
         credentialProvider: CredentialProviderProtocol
     ) {
-        self.logger = logger
         self.configuration = configuration
         self.credentialProvider = credentialProvider
         
@@ -101,6 +99,12 @@ class PubsubClient: PubsubClientProtocol {
                 }
         } catch {
             fatalError("Failed to open GRPC channel")
+        }
+        
+        do {
+            self.logger = try LogProvider.getLogger(name: "PubsubClient")
+        } catch  {
+            fatalError("Failed to initialize PubsubClient logger")
         }
         
         let headers = ["agent": "swift:0.1.0"]
@@ -163,7 +167,7 @@ class PubsubClient: PubsubClientProtocol {
         request.topic = topicName
         
         let result = self.client.subscribe(request)
-        return TopicSubscribeSuccess(subscription: result, logger: self.logger)
+        return TopicSubscribeSuccess(subscription: result)
     }
     
     func close() {

--- a/Sources/momento/internal/PubsubClient.swift
+++ b/Sources/momento/internal/PubsubClient.swift
@@ -81,6 +81,7 @@ class PubsubClient: PubsubClientProtocol {
     ) {
         self.configuration = configuration
         self.credentialProvider = credentialProvider
+        self.logger = LogProvider.getLogger(name: "PubsubClient")
         
         do {
             self.sharedChannel = try GRPCChannelPool.with(
@@ -99,12 +100,6 @@ class PubsubClient: PubsubClientProtocol {
                 }
         } catch {
             fatalError("Failed to open GRPC channel")
-        }
-        
-        do {
-            self.logger = try LogProvider.getLogger(name: "PubsubClient")
-        } catch  {
-            fatalError("Failed to initialize PubsubClient logger")
         }
         
         let headers = ["agent": "swift:0.1.0"]

--- a/Sources/momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/momento/messages/responses/topics/TopicSubscribe.swift
@@ -5,7 +5,7 @@ public protocol TopicSubscribeResponse {}
 
 @available(macOS 10.15, iOS 13, *)
 public class TopicSubscribeSuccess: TopicSubscribeResponse {
-    public var subscription: AsyncCompactMapSequence<GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, TopicSubscriptionItemResponse>
+    public let subscription: AsyncCompactMapSequence<GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, TopicSubscriptionItemResponse>
     
     init(subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>) {
         self.subscription = subscription.compactMap(processResult)

--- a/Sources/momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/momento/messages/responses/topics/TopicSubscribe.swift
@@ -5,31 +5,33 @@ public protocol TopicSubscribeResponse {}
 
 @available(macOS 10.15, iOS 13, *)
 public class TopicSubscribeSuccess: TopicSubscribeResponse {
-    public lazy var subscription: AsyncCompactMapSequence<GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, TopicSubscriptionItemResponse> = _subscription.compactMap(self.processResult)
+    public var subscription: AsyncCompactMapSequence<GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, TopicSubscriptionItemResponse>
     
-    private let _subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>
-    
-    private let logger: MomentoLoggerProtocol
-    
-    init(subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, logger: MomentoLoggerProtocol) {
-        self._subscription = subscription
-        self.logger = logger
+    init(subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>) {
+        self.subscription = subscription.compactMap(processResult)
+    }
+}
+
+internal func processResult(item: CacheClient_Pubsub__SubscriptionItem) -> TopicSubscriptionItemResponse? {
+    var logger: MomentoLoggerProtocol
+    do {
+        logger = try LogProvider.getLogger(name: "TopicSubscribeResponse")
+    } catch {
+        fatalError("Failed to initialize TopicSubscribeResponse logger")
     }
     
-    internal func processResult(item: CacheClient_Pubsub__SubscriptionItem) -> TopicSubscriptionItemResponse? {
-        let messageType = item.kind
-        switch messageType {
-        case .item:
-            return createTopicItemResponse(item: item.item)
-        case .heartbeat:
-            self.logger.info(msg: "topic client received a heartbeat")
-        case .discontinuity:
-            self.logger.info(msg: "topic client received a discontinuity")
-        default:
-            self.logger.error(msg: "topic client received unknown subscription item: \(item)")
-        }
-        return nil
+    let messageType = item.kind
+    switch messageType {
+    case .item:
+        return createTopicItemResponse(item: item.item)
+    case .heartbeat:
+        logger.info(msg: "topic client received a heartbeat")
+    case .discontinuity:
+        logger.info(msg: "topic client received a discontinuity")
+    default:
+        logger.error(msg: "topic client received unknown subscription item: \(item)")
     }
+    return nil
 }
 
 public class TopicSubscribeError: ErrorResponseBase, TopicSubscribeResponse {}

--- a/Sources/momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/momento/messages/responses/topics/TopicSubscribe.swift
@@ -13,13 +13,7 @@ public class TopicSubscribeSuccess: TopicSubscribeResponse {
 }
 
 internal func processResult(item: CacheClient_Pubsub__SubscriptionItem) -> TopicSubscriptionItemResponse? {
-    var logger: MomentoLoggerProtocol
-    do {
-        logger = try LogProvider.getLogger(name: "TopicSubscribeResponse")
-    } catch {
-        fatalError("Failed to initialize TopicSubscribeResponse logger")
-    }
-    
+    let logger = LogProvider.getLogger(name: "TopicSubscribeResponse")
     let messageType = item.kind
     switch messageType {
     case .item:

--- a/Sources/momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/momento/messages/responses/topics/TopicSubscribe.swift
@@ -12,20 +12,19 @@ public class TopicSubscribeSuccess: TopicSubscribeResponse {
     }
 }
 
+public var subscribeLogger = DefaultMomentoLogger(loggerName: "momento-topics-subscribe", level: DefaultMomentoLoggerLevel.debug)
+
 internal func processResult(item: CacheClient_Pubsub__SubscriptionItem) -> TopicSubscriptionItemResponse? {
     let messageType = item.kind
     switch messageType {
     case .item:
         return createTopicItemResponse(item: item.item)
     case .heartbeat:
-        // TODO: should go to a logger
-        print("topic client received a heartbeat")
+        subscribeLogger.info(msg: "topic client received a heartbeat")
     case .discontinuity:
-        // TODO: should go to a logger
-        print("topic client received a discontinuity")
+        subscribeLogger.info(msg: "topic client received a discontinuity")
     default:
-        // TODO: should go to a logger
-        print("topic client received unknown subscription item: \(item)")
+        subscribeLogger.error(msg: "topic client received unknown subscription item: \(item)")
     }
     return nil
 }


### PR DESCRIPTION
### Third attempt

Tried Pete's suggestion of creating a LogProvider class with static methods that can be accessed internally by momento code, such as the `TopicSubscribeSuccess` class.

### Second attempt

Think I found a better way to pass the logger along by lazily initializing the `TopicSubscribeSuccess.subscription` variable.

### First attempt

Ended up creating a new logger that will specifically log messages from the `TopicSubscribeSuccess` class.

Not sure if this is the best way to go about logging the messages, but I couldn't bring the `processResult` function into the `TopicSubscribeSuccess` due to the init function, which uses the processResult function before the class is fully initialized (or at least that's my understanding of it).

```
init(subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>) {
     self.subscription = subscription.compactMap(processResult)
}
```
