### PR TITLE
fix: available tags should include iOS 13

### DIFF
--- a/Sources/momento/TopicClient.swift
+++ b/Sources/momento/TopicClient.swift
@@ -25,7 +25,7 @@ public class TopicClient: TopicClientProtocol {
     private let pubsubClient: PubsubClientProtocol
     private let credentialProvider: CredentialProviderProtocol
     
-    @available(macOS 10.15, *)
+    @available(macOS 10.15, iOS 13, *)
     public init(
         configuration: TopicClientConfigurationProtocol,
         credentialProvider: CredentialProviderProtocol

--- a/Sources/momento/internal/PubsubClient.swift
+++ b/Sources/momento/internal/PubsubClient.swift
@@ -66,7 +66,7 @@ protocol PubsubClientProtocol {
     func close()
 }
 
-@available(macOS 10.15, *)
+@available(macOS 10.15, iOS 13, *)
 class PubsubClient: PubsubClientProtocol {
     var logger: MomentoLoggerProtocol
     var configuration: TopicClientConfigurationProtocol


### PR DESCRIPTION
During my first attempt at consuming the momento package through a url in an example app, I discovered that it would not let me build when `iOS 13` was missing from the `available` tags on the TopicClient and PubsubClient. 