### PR TITLE
chore: topics example should consume package from url and github actions should build example in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,19 @@ jobs:
 
       - name: Run test
         run: swift test
+
+  topics-example:
+    runs-on: ubuntu-latest
+    container: swift:5.8
+    steps:
+    #   - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+    #     with:
+    #         swift-version: ${{ matrix.swift }}
+      - name: Setup repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.github-token }}
+
+      - name: Build
+        run: swift build
+

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+
+.DS_Store

--- a/Examples/topics/Package.resolved
+++ b/Examples/topics/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "client-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/momentohq/client-sdk-swift",
+      "state" : {
+        "revision" : "385ffa1d6b887c035243dd50f1973437279fe950",
+        "version" : "0.2.1"
+      }
+    },
+    {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",

--- a/Examples/topics/Package.swift
+++ b/Examples/topics/Package.swift
@@ -13,7 +13,11 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "momento", path: "../.."),
+        .package(
+            name: "momento", 
+            url: "https://github.com/momentohq/client-sdk-swift", 
+            "0.2.1"..."0.2.1"
+        )
     ],
     targets: [
         .executableTarget(

--- a/Examples/topics/Package.swift
+++ b/Examples/topics/Package.swift
@@ -13,17 +13,13 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(
-            name: "momento", 
-            url: "https://github.com/momentohq/client-sdk-swift", 
-            "0.2.1"..."0.2.1"
-        )
+        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.2.1")
     ],
     targets: [
         .executableTarget(
             name: "momento-topics-example",
             dependencies: [
-                "momento",
+                .product(name: "momento", package: "client-sdk-swift"),
             ],
             path: "Sources"
         ),

--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ To get started with Momento you will need a Momento API key. You can get one fro
 The Momento Swift SDK is available here on github: [momentohq/client-sdk-swift](https://github.com/momentohq/client-sdk-swift). Add the following to the `dependencies` section of your `Package.swift` file to include the SDK in your project:
 
 ```bash
-.package(
-    name: "momento", 
-    url: "https://github.com/momentohq/client-sdk-swift", 
-    "0.2.1"..."0.2.1"
-)
+.package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.2.1")
+```
+
+Your target dependencies will refer to the Momento SDK like so:
+
+```bash
+dependencies: [
+    .product(name: "momento", package: "client-sdk-swift"),
+],
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ To get started with Momento you will need a Momento API key. You can get one fro
 The Momento Swift SDK is available here on github: [momentohq/client-sdk-swift](https://github.com/momentohq/client-sdk-swift). Add the following to the `dependencies` section of your `Package.swift` file to include the SDK in your project:
 
 ```bash
-.package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.2.0")
+.package(
+    name: "momento", 
+    url: "https://github.com/momentohq/client-sdk-swift", 
+    "0.2.1"..."0.2.1"
+)
 ```
 
 ## Usage


### PR DESCRIPTION
Addresses #53 

Need to ensure that target dependencies are able to find the Momento SDK by specifying `.product(name: "momento", package: "client-sdk-swift")`

