### PR TITLE
chore: rename prebuilt config classes and targets for clarity

### DIFF
--- a/Sources/Momento/config/CacheConfigurations.swift
+++ b/Sources/Momento/config/CacheConfigurations.swift
@@ -2,10 +2,12 @@
 public enum CacheClientConfigurations {
 
     public enum iOS {
+        /// Provides the default configuration for the `TopicClient` on iOS platforms
         public static func defaultConfig() -> CacheClientConfiguration {
             return latest()
         }
         
+        /// Provides the latest recommended configuration for the `TopicClient` on iOS platforms
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -16,10 +18,12 @@ public enum CacheClientConfigurations {
     }
     
     public enum macOS {
+        /// Provides the default configuration for the `TopicClient` on macOS platforms
         public static func defaultConfig() -> CacheClientConfiguration {
             return latest()
         }
         
+        /// Provides the latest recommended configuration for the `TopicClient` on macOS platforms
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(

--- a/Sources/Momento/config/CacheConfigurations.swift
+++ b/Sources/Momento/config/CacheConfigurations.swift
@@ -2,6 +2,10 @@
 public enum CacheClientConfigurations {
 
     public enum iOS {
+        public static func defaultConfig() -> CacheClientConfiguration {
+            return latest()
+        }
+        
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -12,6 +16,10 @@ public enum CacheClientConfigurations {
     }
     
     public enum macOS {
+        public static func defaultConfig() -> CacheClientConfiguration {
+            return latest()
+        }
+        
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(

--- a/Sources/Momento/config/CacheConfigurations.swift
+++ b/Sources/Momento/config/CacheConfigurations.swift
@@ -2,12 +2,12 @@
 public enum CacheClientConfigurations {
 
     public enum iOS {
-        /// Provides the default configuration for the `TopicClient` on iOS platforms
+        /// Provides the default configuration for the `CacheClient` on iOS platforms
         public static func defaultConfig() -> CacheClientConfiguration {
             return latest()
         }
         
-        /// Provides the latest recommended configuration for the `TopicClient` on iOS platforms
+        /// Provides the latest recommended configuration for the `CacheClient` on iOS platforms
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -18,12 +18,12 @@ public enum CacheClientConfigurations {
     }
     
     public enum macOS {
-        /// Provides the default configuration for the `TopicClient` on macOS platforms
+        /// Provides the default configuration for the `CacheClient` on macOS platforms
         public static func defaultConfig() -> CacheClientConfiguration {
             return latest()
         }
         
-        /// Provides the latest recommended configuration for the `TopicClient` on macOS platforms
+        /// Provides the latest recommended configuration for the `CacheClient` on macOS platforms
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(

--- a/Sources/Momento/config/CacheConfigurations.swift
+++ b/Sources/Momento/config/CacheConfigurations.swift
@@ -1,8 +1,7 @@
 /// Prebuilt configurations for Momento Cache clients
-public enum CacheConfigurations {
+public enum CacheClientConfigurations {
 
-    public enum Default {
-
+    public enum iOS {
         public static func latest() -> CacheClientConfiguration {
             return CacheClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -10,11 +9,16 @@ public enum CacheConfigurations {
                 )
             )
         }
-
-        public static func v1()  -> CacheClientConfiguration {
-            return latest()
+    }
+    
+    public enum macOS {
+        public static func latest() -> CacheClientConfiguration {
+            return CacheClientConfiguration(
+                transportStrategy: StaticTransportStrategy(
+                    grpcConfig: StaticGrpcConfiguration(deadline: 15.0)
+                )
+            )
         }
-
     }
 
 }

--- a/Sources/Momento/config/TopicConfigurations.swift
+++ b/Sources/Momento/config/TopicConfigurations.swift
@@ -2,6 +2,10 @@
 public enum TopicClientConfigurations {
 
     public enum iOS {
+        public static func defaultConfig() -> TopicClientConfiguration {
+            return latest()
+        }
+        
         public static func latest() -> TopicClientConfiguration {
             return TopicClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -12,6 +16,10 @@ public enum TopicClientConfigurations {
     }
     
     public enum macOS {
+        public static func defaultConfig() -> TopicClientConfiguration {
+            return latest()
+        }
+        
         public static func latest() -> TopicClientConfiguration {
             return TopicClientConfiguration(
                 transportStrategy: StaticTransportStrategy(

--- a/Sources/Momento/config/TopicConfigurations.swift
+++ b/Sources/Momento/config/TopicConfigurations.swift
@@ -2,10 +2,12 @@
 public enum TopicClientConfigurations {
 
     public enum iOS {
+        /// Provides the default configuration for the `TopicClient` on iOS platforms
         public static func defaultConfig() -> TopicClientConfiguration {
             return latest()
         }
         
+        /// Provides the latest recommended configuration for the `TopicClient` on iOS platforms
         public static func latest() -> TopicClientConfiguration {
             return TopicClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -16,10 +18,12 @@ public enum TopicClientConfigurations {
     }
     
     public enum macOS {
+        /// Provides the default configuration for the `TopicClient` on macOS platforms
         public static func defaultConfig() -> TopicClientConfiguration {
             return latest()
         }
         
+        /// Provides the latest recommended configuration for the `TopicClient` on macOS platforms
         public static func latest() -> TopicClientConfiguration {
             return TopicClientConfiguration(
                 transportStrategy: StaticTransportStrategy(

--- a/Sources/Momento/config/TopicConfigurations.swift
+++ b/Sources/Momento/config/TopicConfigurations.swift
@@ -1,8 +1,7 @@
 /// Prebuilt configurations for Momento Topics clients
-public enum TopicConfigurations {
+public enum TopicClientConfigurations {
 
-    public enum Default {
-
+    public enum iOS {
         public static func latest() -> TopicClientConfiguration {
             return TopicClientConfiguration(
                 transportStrategy: StaticTransportStrategy(
@@ -10,11 +9,16 @@ public enum TopicConfigurations {
                 )
             )
         }
-
-        public static func v1()  -> TopicClientConfiguration {
-            return latest()
+    }
+    
+    public enum macOS {
+        public static func latest() -> TopicClientConfiguration {
+            return TopicClientConfiguration(
+                transportStrategy: StaticTransportStrategy(
+                    grpcConfig: StaticGrpcConfiguration(deadline: 15.0)
+                )
+            )
         }
-
     }
 
 }

--- a/Tests/MomentoTests/configTests.swift
+++ b/Tests/MomentoTests/configTests.swift
@@ -25,7 +25,7 @@ final class configTests: XCTestCase {
         XCTAssertNotNil(creds)
         
         let client = TopicClient(
-            configuration: TopicConfigurations.Default.latest(),
+            configuration: TopicClientConfigurations.iOS.latest(),
             credentialProvider: creds
         )
         XCTAssertNotNil(client)
@@ -44,7 +44,7 @@ final class configTests: XCTestCase {
 
     func testTimeoutForImpossibleDeadline() async throws {
         let creds = try CredentialProvider.fromEnvironmentVariable(envVariableName: apiKeyEnvVarName)
-        let configuration = TopicConfigurations.Default.latest().withClientTimeout(timeout: 0.001)
+        let configuration = TopicClientConfigurations.iOS.latest().withClientTimeout(timeout: 0.001)
         let topicClient = TopicClient(configuration: configuration, credentialProvider: creds)
         
         let pubResp = await topicClient.publish(

--- a/Tests/MomentoTests/testUtils.swift
+++ b/Tests/MomentoTests/testUtils.swift
@@ -14,12 +14,12 @@ func setUpIntegrationTests() async -> TestSetup {
         let creds = try CredentialProvider.fromEnvironmentVariable(envVariableName: apiKeyEnvVarName)
         
         let topicClient = TopicClient(
-            configuration: TopicConfigurations.Default.latest(),
+            configuration: TopicClientConfigurations.iOS.latest(),
             credentialProvider: creds
         )
 
         let cacheClient = CacheClient(
-            configuration: CacheConfigurations.Default.latest().withClientTimeout(timeout: 30),
+            configuration: CacheClientConfigurations.iOS.latest().withClientTimeout(timeout: 30),
             credentialProvider: creds,
             defaultTtlSeconds: 10
         )


### PR DESCRIPTION
Addresses #81 except for the docstrings; I'll come back to that with the docstrings ticket