### PR TITLE
chore: add custom strings to print response types and values if applicable

### DIFF
--- a/Sources/Momento/errors/Errors.swift
+++ b/Sources/Momento/errors/Errors.swift
@@ -41,10 +41,6 @@ public class SdkError: Error, ErrorResponseBaseProtocol {
     let transportDetails: MomentoErrorTransportDetails?
     let messageWrapper: String
     
-    var description: String {
-        return "\(self.errorCode): \(self.message)"
-    }
-    
     init(
         message: String,
         errorCode: MomentoErrorCode,

--- a/Sources/Momento/messages/responses/ResponseBase.swift
+++ b/Sources/Momento/messages/responses/ResponseBase.swift
@@ -1,4 +1,4 @@
-public class ErrorResponseBase: ErrorResponseBaseProtocol {
+public class ErrorResponseBase: ErrorResponseBaseProtocol, CustomStringConvertible {
     var error: SdkError
     public var message: String { return self.error.message }
     public var errorCode: MomentoErrorCode { return self.error.errorCode }
@@ -9,6 +9,6 @@ public class ErrorResponseBase: ErrorResponseBaseProtocol {
     }
 
     public var description: String {
-        return "Error: \(self.errorCode) \(self.error.messageWrapper): \(self.error.message)"
+        return "[\(self.errorCode)] \(self.error.messageWrapper): \(self.error.message)"
     }
 }

--- a/Sources/Momento/messages/responses/cache/control/ListCaches.swift
+++ b/Sources/Momento/messages/responses/cache/control/ListCaches.swift
@@ -11,13 +11,17 @@ public enum ListCachesResponse {
     case error(ListCachesError)
 }
 
-public class ListCachesSuccess {
+public class ListCachesSuccess: CustomStringConvertible {
     public let caches: [CacheInfo]
     
     init(caches: [ControlClient__Cache]) {
         self.caches = caches.map({ cache in
             return CacheInfo(name: cache.cacheName)
         })
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] Length of caches list: \(self.caches.count)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListConcatenateBack.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListConcatenateBack.swift
@@ -3,11 +3,15 @@ public enum ListConcatenateBackResponse {
     case error(ListConcatenateBackError)
 }
 
-public class ListConcatenateBackSuccess {
+public class ListConcatenateBackSuccess: CustomStringConvertible {
     public let listLength: UInt32
 
     init(length: UInt32) {
         self.listLength = length
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] List length post-concatenation: \(self.listLength)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListConcatenateFront.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListConcatenateFront.swift
@@ -3,11 +3,15 @@ public enum ListConcatenateFrontResponse {
     case error(ListConcatenateFrontError)
 }
 
-public class ListConcatenateFrontSuccess {
+public class ListConcatenateFrontSuccess: CustomStringConvertible {
     public let listLength: UInt32
     
     init(length: UInt32) {
         self.listLength = length
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] List length post-concatenation: \(self.listLength)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListFetch.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListFetch.swift
@@ -6,13 +6,17 @@ public enum ListFetchResponse {
     case error(ListFetchError)
 }
 
-public class ListFetchHit {
+public class ListFetchHit: CustomStringConvertible {
     public let valueListString: [String]
     public let valueListData: [Data]
     
     init(values: [Data]) {
         self.valueListData = values
         self.valueListString = values.map { String(decoding: $0, as: UTF8.self) }
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] List length: \(self.valueListData.count)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListLength.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListLength.swift
@@ -6,11 +6,15 @@ public enum ListLengthResponse {
     case error(ListLengthError)
 }
 
-public class ListLengthHit {
+public class ListLengthHit: CustomStringConvertible {
     public let length: UInt32
     
     init(length: UInt32) {
         self.length = length
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] List length: \(self.length)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListPopBack.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPopBack.swift
@@ -6,13 +6,17 @@ public enum ListPopBackResponse {
     case error(ListPopBackError)
 }
 
-public class ListPopBackHit {
+public class ListPopBackHit: CustomStringConvertible {
     public let valueString: String
     public let valueData: Data
     
     init(value: Data) {
         self.valueData = value
         self.valueString = String(decoding: value, as: UTF8.self)
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] Popped value: \(self.valueString)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListPopFront.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPopFront.swift
@@ -6,13 +6,17 @@ public enum ListPopFrontResponse {
     case error(ListPopFrontError)
 }
 
-public class ListPopFrontHit {
+public class ListPopFrontHit: CustomStringConvertible {
     public let valueString: String
     public let valueData: Data
     
     init(value: Data) {
         self.valueData = value
         self.valueString = String(decoding: value, as: UTF8.self)
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] Popped value: \(self.valueString)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListPushBack.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPushBack.swift
@@ -3,11 +3,15 @@ public enum ListPushBackResponse {
     case error(ListPushBackError)
 }
 
-public class ListPushBackSuccess {
+public class ListPushBackSuccess: CustomStringConvertible {
     public let listLength: UInt32
     
     init(length: UInt32) {
         self.listLength = length
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] List length after push: \(self.listLength)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/list/ListPushFront.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPushFront.swift
@@ -3,11 +3,15 @@ public enum ListPushFrontResponse {
     case error(ListPushFrontError)
 }
 
-public class ListPushFrontSuccess {
+public class ListPushFrontSuccess: CustomStringConvertible {
     public let listLength: UInt32
     
     init(length: UInt32) {
         self.listLength = length
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] List length after push: \(self.listLength)"
     }
 }
 

--- a/Sources/Momento/messages/responses/cache/data/scalar/Get.swift
+++ b/Sources/Momento/messages/responses/cache/data/scalar/Get.swift
@@ -6,7 +6,7 @@ public enum GetResponse {
     case error(GetError)
 }
 
-public class GetHit: Equatable {
+public class GetHit: Equatable, CustomStringConvertible {
     public let valueString: String
     public let valueData: Data
     
@@ -17,6 +17,10 @@ public class GetHit: Equatable {
 
     public static func == (lhs: GetHit, rhs: GetHit) -> Bool {
         return lhs.valueData == rhs.valueData
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] Value: \(self.valueString)"
     }
 }
 

--- a/Sources/Momento/messages/responses/topics/TopicSubscriptionItem.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscriptionItem.swift
@@ -6,19 +6,27 @@ public enum TopicSubscriptionItemResponse {
     case error(TopicSubscriptionItemError)
 }
 
-public class TopicSubscriptionItemText {
+public class TopicSubscriptionItemText: CustomStringConvertible {
     public let value: String
     
     init(value: String) {
         self.value = value
     }
+    
+    public var description: String {
+        return "[\(type(of: self))] Value: \(self.value)"
+    }
 }
 
-public class TopicSubscriptionItemBinary {
+public class TopicSubscriptionItemBinary: CustomStringConvertible {
     public let value: Data
     
     init(value: Data) {
         self.value = value
+    }
+    
+    public var description: String {
+        return "[\(type(of: self))] Value: \(self.value)"
     }
 }
 

--- a/Sources/Momento/messages/responses/topics/TopicSubscriptionItem.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscriptionItem.swift
@@ -26,7 +26,7 @@ public class TopicSubscriptionItemBinary: CustomStringConvertible {
     }
     
     public var description: String {
-        return "[\(type(of: self))] Value: \(self.value)"
+        return "[\(type(of: self))] Value: \(String(decoding: self.value, as: UTF8.self))"
     }
 }
 


### PR DESCRIPTION
Addresses #84 

By default, printing response classes that don't have associated values will print their class names:
```
success(Momento.CreateCacheSuccess)
alreadyExists(Momento.CreateCacheAlreadyExists)
miss(Momento.GetMiss)
```

Adding these custom strings allow for more informational prints about errors and classes with associated values:
```
success([ListCachesSuccess] Length of caches list: 4)
hit([GetHit] Value: xyz)
success([ListConcatenateFrontSuccess] List length post-concatenation: 2)
hit([ListFetchHit] List length: 2)
error([INVALID_ARGUMENT_ERROR] Invalid argument passed to Momento client: Invalid cache name)
```