### PR TITLE
fix: actually build the topics example in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,5 +47,5 @@ jobs:
           token: ${{ secrets.github-token }}
 
       - name: Build
-        run: swift build
+        run: cd Examples/topics && swift build
 

--- a/Examples/topics/Package.swift
+++ b/Examples/topics/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Topics example should use swift-tools-version 5.7 and CI should actually `cd` into the topics directory to build the example