### PR TITLE
feat: topics subscription resiliency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The default logging backend provided by swift-log ([`StreamLogHandler`](https://
 
 To change the logging level and/or redirect logs to stderr, you would call  [`LoggingSystem.bootstrap(...)`](https://github.com/apple/swift-log/#default-logger-behavior) once at the beginning of your program like so:
 ```
-LoggingSystem.bootstrap {
+LoggingSystem.bootstrap { _ in
     var handler = StreamLogHandler.standardError(label: "momento-logger")
     handler.logLevel = .debug
     return handler

--- a/Sources/Momento/TopicClient.swift
+++ b/Sources/Momento/TopicClient.swift
@@ -167,7 +167,8 @@ public class TopicClient: TopicClientProtocol {
         do {
             let result = try await self.pubsubClient.subscribe(
                 cacheName: cacheName, 
-                topicName: topicName
+                topicName: topicName, 
+                resumeAtTopicSequenceNumber: nil
             )
             return result
         } catch {

--- a/Sources/Momento/internal/PubsubClient.swift
+++ b/Sources/Momento/internal/PubsubClient.swift
@@ -28,7 +28,7 @@ class PubsubClient: PubsubClientProtocol {
     let configuration: TopicClientConfigurationProtocol
     let credentialProvider: CredentialProviderProtocol
     let eventLoopGroup = PlatformSupport.makeEventLoopGroup(loopCount: 1)
-    let headers = ["agent": "swift:0.1.0"]
+    let headers = ["agent": "swift:0.3.2"]
     let grpcManager: TopicsGrpcManager
     let client: CacheClient_Pubsub_PubsubAsyncClient
     

--- a/Sources/Momento/internal/TopicsGrpcManager.swift
+++ b/Sources/Momento/internal/TopicsGrpcManager.swift
@@ -1,0 +1,46 @@
+import GRPC
+import NIO
+import NIOHPACK
+
+@available(macOS 10.15, iOS 13, *)
+internal class TopicsGrpcManager {
+    var channel: GRPCChannel
+    var client: CacheClient_Pubsub_PubsubAsyncClient
+    
+    init(
+        credentialProvider: CredentialProviderProtocol,
+        eventLoopGroup: EventLoopGroup,
+        headers: [String: String]
+    ) {
+        do {
+            self.channel = try GRPCChannelPool.with(
+                target: .host(credentialProvider.cacheEndpoint, port: 443),
+                transportSecurity: .tls(
+                    GRPCTLSConfiguration.makeClientDefault(compatibleWith: eventLoopGroup)
+                ),
+                eventLoopGroup: eventLoopGroup
+            ) { configuration in
+                // Additional configuration, like keepalive.
+                // Note: Keepalive should in most circumstances not be necessary.
+                configuration.keepalive = ClientConnectionKeepalive(
+                    interval: .seconds(15),
+                    timeout: .seconds(10)
+                )
+            }
+        } catch {
+            fatalError("Failed to open GRPC channel")
+        }
+        
+        self.client = CacheClient_Pubsub_PubsubAsyncClient(
+            channel: self.channel,
+            defaultCallOptions: .init(
+                customMetadata: .init(headers.map { ($0, $1) })
+            ),
+            interceptors: PubsubClientInterceptorFactory(apiKey: credentialProvider.apiKey)
+        )
+    }
+    
+    func getClient() -> CacheClient_Pubsub_PubsubAsyncClient {
+        return self.client
+    }
+}

--- a/Sources/Momento/internal/TopicsGrpcManager.swift
+++ b/Sources/Momento/internal/TopicsGrpcManager.swift
@@ -23,8 +23,8 @@ internal class TopicsGrpcManager {
                 // Additional configuration, like keepalive.
                 // Note: Keepalive should in most circumstances not be necessary.
                 configuration.keepalive = ClientConnectionKeepalive(
-                    interval: .seconds(15),
-                    timeout: .seconds(10)
+                    interval: .seconds(10),
+                    timeout: .seconds(5)
                 )
             }
         } catch {

--- a/Sources/Momento/internal/TopicsGrpcManager.swift
+++ b/Sources/Momento/internal/TopicsGrpcManager.swift
@@ -43,4 +43,8 @@ internal class TopicsGrpcManager {
     func getClient() -> CacheClient_Pubsub_PubsubAsyncClient {
         return self.client
     }
+    
+    func close() {
+        let _ = self.channel.close()
+    }
 }

--- a/Sources/Momento/messages/responses/ResponseBase.swift
+++ b/Sources/Momento/messages/responses/ResponseBase.swift
@@ -1,4 +1,4 @@
-public class ErrorResponseBase: ErrorResponseBaseProtocol, CustomStringConvertible {
+public class ErrorResponseBase: ErrorResponseBaseProtocol, Error, CustomStringConvertible {
     var error: SdkError
     public var message: String { return self.error.message }
     public var errorCode: MomentoErrorCode { return self.error.errorCode }

--- a/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
@@ -1,4 +1,5 @@
 import GRPC
+import Foundation
 import Logging
 
 /**
@@ -23,29 +24,104 @@ public enum TopicSubscribeResponse {
 /// Encapsulates a topic subscription. Iterate over the subscription's `stream` property to retrieve `TopicSubscriptionItemResponse` objects containing data published to the topic.
 @available(macOS 10.15, iOS 13, *)
 public class TopicSubscription {
-    public typealias SubscriptionItemsMap = AsyncCompactMapSequence<GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, TopicSubscriptionItemResponse>
+    private var subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>
+    private var lastSequenceNumber: UInt64
+    private let pubsubClient: PubsubClientProtocol
+    private let logger = Logger(label: "TopicSubscribeResponse")
+    private var retry = true
+    private let cacheName: String
+    private let topicName: String
     
-    public let stream: SubscriptionItemsMap
+    lazy private var messageIterator = subscription.makeAsyncIterator()
     
-    init(subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>) {
-        self.stream = subscription.compactMap(processResult)
+    // Constructs an AsyncStream of subscription items using the iterator provided
+    // by the GRPCAsyncResponseStream object.
+    // If the iterator throws a `cancelled` GRPC status code, the AsyncStream will stop.
+    // If the user calls `unsubscribe` (sets the retry boolean to false), the AsyncStream will stop.
+    // Otherwise, given any other error, it will attempt to resubscribe (get new GRPCAsyncResponseStream
+    // and corresponding iterator).
+    lazy public var stream = AsyncStream<TopicSubscriptionItemResponse> {
+        while (self.retry) {
+            do {
+                let item = try await self.messageIterator.next()
+                if let nonNilItem = item {
+                    if let processedItem = self.processResult(item: nonNilItem) {
+                        return processedItem
+                    }
+                } else {
+                    self.logger.debug("Received nil from iterator, attempting to resubscribe")
+                    await self.attemptResubscribe()
+                }
+                
+            } catch let err as GRPCStatus {
+                if (err.code == .cancelled) {
+                    self.logger.debug("Canceled, not resubscribing")
+                    return nil
+                } else {
+                    self.logger.debug("Caught GRPCStatus \(err), attempting to resubscribe")
+                    await self.attemptResubscribe()
+                }
+            } catch {
+                self.logger.error("Unknown error from iterator: \(error.localizedDescription), attempting to resubscribe")
+                await self.attemptResubscribe()
+            }
+        }
+        return nil
     }
-}
-
-internal func processResult(item: CacheClient_Pubsub__SubscriptionItem) -> TopicSubscriptionItemResponse? {
-    let logger = Logger(label: "TopicSubscribeResponse")
-    let messageType = item.kind
-    switch messageType {
-    case .item:
-        return createTopicItemResponse(item: item.item)
-    case .heartbeat:
-        logger.debug("topic client received a heartbeat")
-    case .discontinuity:
-        logger.debug("topic client received a discontinuity")
-    default:
-        logger.error("topic client received unknown subscription item: \(item)")
+    
+    init(
+        subscription: GRPCAsyncResponseStream<CacheClient_Pubsub__SubscriptionItem>, 
+        lastSequenceNumber: UInt64,
+        pubsubClient: PubsubClientProtocol,
+        cacheName: String,
+        topicName: String
+    ) {
+        self.lastSequenceNumber = lastSequenceNumber
+        self.pubsubClient = pubsubClient
+        self.cacheName = cacheName
+        self.topicName = topicName
+        self.subscription = subscription
     }
-    return nil
+    
+    public func unsubscribe() {
+        self.retry = false
+    }
+    
+    internal func processResult(item: CacheClient_Pubsub__SubscriptionItem) -> TopicSubscriptionItemResponse? {
+        let messageType = item.kind
+        switch messageType {
+        case .item:
+            lastSequenceNumber = item.item.topicSequenceNumber
+            return createTopicItemResponse(item: item.item)
+        case .heartbeat:
+            logger.debug("topic client received a heartbeat")
+        case .discontinuity:
+            logger.debug("topic client received a discontinuity")
+        default:
+            logger.error("topic client received unknown subscription item: \(item)")
+        }
+        return nil
+    }
+    
+    internal func attemptResubscribe() async {
+        do {
+            let subResp = try await self.pubsubClient.subscribe(
+                cacheName: self.cacheName,
+                topicName: self.topicName,
+                resumeAtTopicSequenceNumber: self.lastSequenceNumber
+            )
+            switch (subResp) {
+            case .subscription(let s):
+                self.subscription = s.subscription
+                self.messageIterator = s.subscription.makeAsyncIterator()
+                logger.debug("Successfully resubscribed")
+            case .error(let err):
+                logger.error("Received error instead of new subscription: \(err)")
+            }
+        } catch {
+            logger.error("Received error while attempting resubscribe: \(error)")
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-swift/issues/106 and part of https://github.com/momentohq/dev-eco-issue-tracker/issues/604 (will need to follow up to update the topics example after this is released).

Creates a Topics GRPC manager class to allow multiple GRPC connections in the pubsub client if needed in the future.
Adds logic for resubscribing on errors that are not cancellation errors.
Adds a way to unsubscribe from a topic (essentially stops the AsyncStream providing the messages).

Manually tested using topics example that it will resubscribe when wifi is turned off for a few minutes and that it will not resubscribe when the user calls unsubscribe to cancel the subscription. 

If you want to test it yourself, the `Package.swift` was modified like so:
```
// swift-tools-version: 5.7
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "momento-topics-example",
    platforms: [.macOS(.v10_15), .iOS(.v13)],
    products: [
        .executable(
            name: "momento-topics-example",
            targets: ["momento-topics-example"]
        ),
    ],
    dependencies: [
        .package(name: "Momento", path: "../.."),
        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
    ],
    targets: [
        .executableTarget(
            name: "momento-topics-example",
            dependencies: [
                "Momento",
                .product(name: "Logging", package: "swift-log")
            ],
            path: "Sources"
        ),
    ]
)
```
