### PR TITLE
fix: add available attribute to cache client protocols

### DIFF
--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -11,6 +11,7 @@ enum ScalarType {
 
 protocol CacheClientProtocol: ControlClientProtocol & DataClientProtocol {}
 
+@available(macOS 10.15, iOS 13, *)
 extension CacheClientProtocol {
     public func get(cacheName: String, key: String) async -> GetResponse {
         return await self.get(cacheName: cacheName, key: ScalarType.string(key))

--- a/Sources/Momento/internal/ControlClient.swift
+++ b/Sources/Momento/internal/ControlClient.swift
@@ -3,6 +3,7 @@ import NIO
 import NIOHPACK
 import Logging
 
+@available(macOS 10.15, iOS 13, *)
 protocol ControlClientProtocol {
     func createCache(cacheName: String) async -> CreateCacheResponse
     

--- a/Sources/Momento/internal/DataClient.swift
+++ b/Sources/Momento/internal/DataClient.swift
@@ -4,6 +4,7 @@ import NIO
 import NIOHPACK
 import Logging
 
+@available(macOS 10.15, iOS 13, *)
 protocol DataClientProtocol {
     func get(cacheName: String, key: ScalarType) async -> GetResponse
 


### PR DESCRIPTION
addresses #111 

Inspected the very large codeql log output and I think it was mostly just complaining that the cache client protocols were missing the `@available` tags