### PR TITLE
fix: availability tag and topics subscriptions fixes

### DIFF
--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -8,7 +8,7 @@ enum ScalarType {
 // The CacheClient class provides user-friendly, public-facing methods
 // with default values for non-required parameters and overloaded functions
 // that accept String and Data values directly rather than ScalarTypes
-
+@available(macOS 10.15, iOS 13, *)
 protocol CacheClientProtocol: ControlClientProtocol & DataClientProtocol {}
 
 @available(macOS 10.15, iOS 13, *)

--- a/Sources/Momento/TopicClient.swift
+++ b/Sources/Momento/TopicClient.swift
@@ -171,6 +171,8 @@ public class TopicClient: TopicClientProtocol {
                 resumeAtTopicSequenceNumber: nil
             )
             return result
+        } catch let err as TopicSubscribeError {
+            return TopicSubscribeResponse.error(err)
         } catch {
             return TopicSubscribeResponse.error(TopicSubscribeError(
                 error: UnknownError(

--- a/Sources/Momento/internal/PubsubClient.swift
+++ b/Sources/Momento/internal/PubsubClient.swift
@@ -87,10 +87,10 @@ class PubsubClient: PubsubClientProtocol {
         request.topic = topicName
         request.resumeAtTopicSequenceNumber = UInt64(resumeAtTopicSequenceNumber ?? 0)
         
-        let result = self.client.subscribe(request)
+        let result = self.client.makeSubscribeCall(request)
         return TopicSubscribeResponse.subscription(
             TopicSubscription(
-                subscription: result,
+                subscribeCallResponse: result,
                 lastSequenceNumber: request.resumeAtTopicSequenceNumber,
                 pubsubClient: self,
                 cacheName: cacheName,

--- a/Sources/Momento/internal/PubsubClient.swift
+++ b/Sources/Momento/internal/PubsubClient.swift
@@ -87,16 +87,40 @@ class PubsubClient: PubsubClientProtocol {
         request.topic = topicName
         request.resumeAtTopicSequenceNumber = UInt64(resumeAtTopicSequenceNumber ?? 0)
         
+        
         let result = self.client.makeSubscribeCall(request)
-        return TopicSubscribeResponse.subscription(
-            TopicSubscription(
-                subscribeCallResponse: result,
-                lastSequenceNumber: request.resumeAtTopicSequenceNumber,
-                pubsubClient: self,
-                cacheName: cacheName,
-                topicName: topicName
+        
+        do {
+            var messageIterator = result.responseStream.makeAsyncIterator()
+            let firstElement = try await messageIterator.next()
+            if let nonNilFirstElement = firstElement {
+                switch nonNilFirstElement.kind {
+                case .heartbeat:
+                    logger.debug("Received heartbeat as first message, returning subscription")
+                    return TopicSubscribeResponse.subscription(
+                        TopicSubscription(
+                            subscribeCallResponse: result,
+                            messageIterator: messageIterator,
+                            lastSequenceNumber: request.resumeAtTopicSequenceNumber,
+                            pubsubClient: self,
+                            cacheName: cacheName,
+                            topicName: topicName
+                        )
+                    )
+                default:
+                    return TopicSubscribeResponse.error(TopicSubscribeError(error: InternalServerError(message: "Expected heartbeat message for topic \(topicName) on cache \(cacheName), got \(String(describing: nonNilFirstElement.kind))")))
+                }
+            }
+            return TopicSubscribeResponse.error(TopicSubscribeError(error: InternalServerError(message: "Expected heartbeat message for topic \(topicName) on cache \(cacheName), got \(String(describing: firstElement))")))
+        } catch let err as GRPCStatus {
+            return TopicSubscribeResponse.error(TopicSubscribeError(error: grpcStatusToSdkError(grpcStatus: err)))
+        } catch let err as GRPCConnectionPoolError {
+            return TopicSubscribeResponse.error(TopicSubscribeError(error: grpcStatusToSdkError(grpcStatus: err.makeGRPCStatus())))
+        } catch {
+            return TopicSubscribeResponse.error(
+                TopicSubscribeError(error: UnknownError(message: "unknown subscribe error \(error)"))
             )
-        )
+        }
     }
     
     func close() {

--- a/Sources/Momento/internal/TopicsGrpcManager.swift
+++ b/Sources/Momento/internal/TopicsGrpcManager.swift
@@ -24,8 +24,10 @@ internal class TopicsGrpcManager {
                 // Note: Keepalive should in most circumstances not be necessary.
                 configuration.keepalive = ClientConnectionKeepalive(
                     interval: .seconds(10),
-                    timeout: .seconds(5)
+                    timeout: .seconds(5),
+                    permitWithoutCalls: true
                 )
+                configuration.connectionPool.connectionsPerEventLoop = 100
             }
         } catch {
             fatalError("Failed to open GRPC channel")

--- a/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
@@ -57,6 +57,9 @@ public class TopicSubscription {
                 if (err.code == .cancelled) {
                     self.logger.debug("Canceled, not resubscribing")
                     return nil
+                } else if (err.code == .resourceExhausted) {
+                    self.logger.debug("Too many subscribers, not resubscribing")
+                    return nil
                 } else {
                     self.logger.debug("Caught GRPCStatus \(err), attempting to resubscribe")
                     await self.attemptResubscribe()


### PR DESCRIPTION
Followup addressing https://github.com/momentohq/client-sdk-swift/issues/106

Unsubscribe was not working correctly (not freeing up the subscription stream). Went back to look at the proto-generated stubs and found `makeSubscribeCall()` as an alternate way to subscribe to a topic, and the response for this method comes with a `cancel()` method and the `AsyncResponseStream` we had been using before. Verified with local testing that resources are actually freed up once a subscription is canceled.

Also implemented a way to check the first message of a subscription, and if it's not a heartbeat, it should return an error. This way, it's possible to send a TopicSubscribeError when all streams are maxed out rather than returning a subscription that will error the first time the user tries to use it.

Test output:
```
Subscription 99 successful!
Subscription error: [LIMIT_EXCEEDED_ERROR] Request rate, bandwidth, or object size exceeded the limits for this account. To resolve this error, reduce your usage as appropriate or contact us at support@momentohq.com to request a limit increase: Too many subscribers (limit: 100). Please contact support@momentohq.com for a limit increase
```

Other small fixes: added missing availability tag, extra configs for topics subscription connections, do not attempt to resubscribe if `resource exhausted` error was received.