### PR TITLE
chore: small error message and docstring fixes

### DIFF
--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -9,6 +9,7 @@ enum ScalarType {
 // with default values for non-required parameters and overloaded functions
 // that accept String and Data values directly rather than ScalarTypes
 
+@available(macOS 10.15, iOS 13, *)
 protocol CacheClientProtocol: ControlClientProtocol & DataClientProtocol {}
 
 @available(macOS 10.15, iOS 13, *)
@@ -277,6 +278,14 @@ public class CacheClient: CacheClientProtocol {
         - configuration: CacheClient configuration object specifying grpc transport strategy and other settings
         - credentialProvider: provides the Momento API key, which you can create in the [Momento Web Console](https://console.gomomento.com/api-keys)
         - defaultTtlSeconds: default time to live for the item in cache
+     
+     ```swift
+     let cacheClient = CacheClient(
+       configuration: CacheClientConfigurations.iOS.latest(),
+       credentialProvider: yourCredentialProvider,
+       defaultTtlSeconds: 10
+     )
+     ```
      */
     public init(
         configuration: CacheClientConfigurationProtocol,
@@ -302,7 +311,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `CacheCreateResponse` representing the result of the create cache operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-    ```
+    ```swift
      switch response {
      case .error(let err):
         print("Error: \(err)")
@@ -330,7 +339,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `DeleteCacheResponse` representing the result of the delete cache operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -357,7 +366,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListCachesResponse` representing the result of the list caches operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -378,7 +387,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `GetResponse` representing the result of the get operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -401,7 +410,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `GetResponse` representing the result of the get operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -440,7 +449,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `SetResponse` representing the result of the set operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -473,7 +482,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `SetResponse` representing the result of the set operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -506,7 +515,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `SetResponse` representing the result of the set operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -539,7 +548,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `SetResponse` representing the result of the set operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -595,7 +604,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `DeleteResponse` representing the result of the set operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -616,7 +625,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `DeleteResponse` representing the result of the set operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -654,7 +663,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListConcatenateBackResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -690,7 +699,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListConcatenateBackResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -757,7 +766,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListConcatenateFrontResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -793,7 +802,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListConcatenateFrontResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -857,7 +866,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListFetchResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -901,7 +910,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListLengthResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -937,7 +946,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListPopBackResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -973,7 +982,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListPopFrontResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1012,7 +1021,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListPushBackResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1050,7 +1059,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListPushBackResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1114,7 +1123,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListPushFrontResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1150,7 +1159,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListPushFrontResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1212,7 +1221,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListRemoveValueResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1238,7 +1247,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListRemoveValueResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")
@@ -1288,7 +1297,7 @@ public class CacheClient: CacheClientProtocol {
      - Returns: `ListRetainResponse` representing the result of the operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch response {
       case .error(let err):
          print("Error: \(err)")

--- a/Sources/Momento/TopicClient.swift
+++ b/Sources/Momento/TopicClient.swift
@@ -36,6 +36,13 @@ public class TopicClient: TopicClientProtocol {
      - Parameters:
         - configuration: TopicClient configuration object specifying grpc transport strategy and other settings
         - credentialProvider: provides the Momento API key, which you can create in the [Momento Web Console](https://console.gomomento.com/api-keys)
+     
+     ```swift
+     let topicClient = TopicClient(
+       configuration: TopicClientConfigurations.iOS.latest(),
+       credentialProvider: yourCredentialProvider
+     )
+     ```
      */
     public init(
         configuration: TopicClientConfigurationProtocol,
@@ -57,7 +64,7 @@ public class TopicClient: TopicClientProtocol {
      - Returns: TopicPublishResponse representing the result of the publish operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-    ```
+    ```swift
      switch publishResponse {
      case .error(let err):
          print("Error: \(err)")
@@ -83,7 +90,7 @@ public class TopicClient: TopicClientProtocol {
      - Returns: TopicPublishResponse representing the result of the publish operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-    ```
+    ```swift
      switch publishResponse {
      case .error(let err):
          print("Error: \(err)")
@@ -143,7 +150,7 @@ public class TopicClient: TopicClientProtocol {
      - Returns: TopicSubscribeResponse representing the result of the subscribe operation.
      
      Pattern matching can be used to operate on the appropriate subtype.
-     ```
+     ```swift
       switch subscribeResponse {
       case .error(let err):
           print("Error: \(err)")

--- a/Sources/Momento/auth/CredentialProvider.swift
+++ b/Sources/Momento/auth/CredentialProvider.swift
@@ -134,7 +134,7 @@ public class StringMomentoTokenProvider : CredentialProviderProtocol {
 public class EnvMomentoTokenProvider : StringMomentoTokenProvider {
     init(envVarName: String = "", controlEndpoint: String? = nil, cacheEndpoint: String? = nil) throws {
         if envVarName.isEmpty {
-            throw CredentialProviderError.emptyAuthEnvironmentVariable()
+            throw CredentialProviderError.emptyAuthEnvironmentVariable(message: "Could not find environment variable \(envVarName) or the variable was an empty string")
         }
         let apiKey = ProcessInfo.processInfo.environment[envVarName]
         try super.init(apiKey: apiKey ?? "", controlEndpoint: controlEndpoint, cacheEndpoint: cacheEndpoint)

--- a/Sources/Momento/config/CacheConfiguration.swift
+++ b/Sources/Momento/config/CacheConfiguration.swift
@@ -24,7 +24,7 @@ public protocol CacheClientConfigurationProtocol {
  Configuration options for Momento CacheClient.
  
  The easiest way to get a `CacheClientConfiguration` object is to use one of the prebuilt CacheClientConfigurations classes.
- ```
+ ```swift
  let config = CacheClientConfigurations.iOS.latest()
  ```
  */

--- a/Sources/Momento/config/TopicConfiguration.swift
+++ b/Sources/Momento/config/TopicConfiguration.swift
@@ -24,7 +24,7 @@ public protocol TopicClientConfigurationProtocol {
  Configuration options for Momento TopicClient.
  
  The easiest way to get a `TopicClientConfiguration` object is to use one of the prebuilt TopicClientConfigurations classes.
- ```
+ ```swift
  let config = TopicClientConfiguration.iOS.latest()
  ```
  */

--- a/Sources/Momento/messages/responses/cache/control/CreateCache.swift
+++ b/Sources/Momento/messages/responses/cache/control/CreateCache.swift
@@ -2,7 +2,7 @@
  Enum for a create cache request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/control/DeleteCache.swift
+++ b/Sources/Momento/messages/responses/cache/control/DeleteCache.swift
@@ -2,7 +2,7 @@
  Enum for a delete cache request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/control/ListCaches.swift
+++ b/Sources/Momento/messages/responses/cache/control/ListCaches.swift
@@ -11,7 +11,7 @@ public class CacheInfo {
  Enum for a list caches request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListConcatenateBack.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListConcatenateBack.swift
@@ -2,7 +2,7 @@
  Enum for a list concatenate back request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListConcatenateFront.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListConcatenateFront.swift
@@ -2,7 +2,7 @@
  Enum for a list concatenate front request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListFetch.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListFetch.swift
@@ -4,7 +4,7 @@ import Foundation
  Enum for a list fetch request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListLength.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListLength.swift
@@ -4,7 +4,7 @@ import Foundation
  Enum for a list length request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListPopBack.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPopBack.swift
@@ -4,7 +4,7 @@ import Foundation
  Enum for a list pop back request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListPopFront.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPopFront.swift
@@ -4,7 +4,7 @@ import Foundation
  Enum for a list pop front request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListPushBack.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPushBack.swift
@@ -2,7 +2,7 @@
  Enum for a list push back request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListPushFront.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListPushFront.swift
@@ -2,7 +2,7 @@
  Enum for a list push front request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListRemoveValue.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListRemoveValue.swift
@@ -2,7 +2,7 @@
  Enum for a list remove value request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/list/ListRetain.swift
+++ b/Sources/Momento/messages/responses/cache/data/list/ListRetain.swift
@@ -2,7 +2,7 @@
  Enum for a list retain request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/scalar/Delete.swift
+++ b/Sources/Momento/messages/responses/cache/data/scalar/Delete.swift
@@ -2,7 +2,7 @@
  Enum for a delete cache item request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/scalar/Get.swift
+++ b/Sources/Momento/messages/responses/cache/data/scalar/Get.swift
@@ -4,7 +4,7 @@ import Foundation
  Enum for a get cache item request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/cache/data/scalar/Set.swift
+++ b/Sources/Momento/messages/responses/cache/data/scalar/Set.swift
@@ -2,7 +2,7 @@
  Enum for a set cache item request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/topics/TopicPublish.swift
+++ b/Sources/Momento/messages/responses/topics/TopicPublish.swift
@@ -2,7 +2,7 @@
  Enum for a topic publish request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
      print("Error: \(err)")

--- a/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
@@ -6,7 +6,7 @@ import Logging
  Enum for a topic subscribe request response type.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
       print("Error: \(err)")

--- a/Sources/Momento/messages/responses/topics/TopicSubscriptionItem.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscriptionItem.swift
@@ -4,7 +4,7 @@ import Foundation
  Enum to represent the data received from a topic subscription.
  
  Pattern matching can be used to operate on the appropriate subtype.
- ```
+ ```swift
   switch response {
   case .error(let err):
       print("Error: \(err)")


### PR DESCRIPTION
Addressing bug bash feedback, #115 and #116, and specifies language as `swift` for docstring code snippets