### PR TITLE
chore: update examples to use latest release and other small updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     container: swift:5.8
     env:
         TEST_API_KEY: ${{ secrets.auth-token }}
+        MOMENTO_API_KEY: ${{ secrets.auth-token }}
     steps:
     #   - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
     #     with:
@@ -38,13 +39,11 @@ jobs:
         run: cd Examples/topics && swift build
 
       - name: Build cache example
-        run: cd Examples/cache && swift build
+        run: cd Examples/cache && swift run
 
       - name: Build quickstart example
         run: cd Examples/quickstart && swift build
       
       - name: Run dev doc examples
-        env:
-          MOMENTO_API_KEY: ${{ secrets.auth-token }}
         run: cd Examples/doc-example-apis && swift run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Happy coding :dancer:
 ## Requirements :coffee:
 
 - Swift version [5.4 or higher](https://www.swift.org/install/) is required
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com)
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys)
 
 <br/>
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com)
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys)
 
 ## Running the examples
 

--- a/Examples/cache/Package.resolved
+++ b/Examples/cache/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/momentohq/client-sdk-swift",
       "state" : {
-        "revision" : "4ba910e0874c3dff48419684be5e9cf24be43150",
-        "version" : "0.3.2"
+        "revision" : "19087b69bc283727a72f552e28df5743de7584f8",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Examples/cache/Package.swift
+++ b/Examples/cache/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.3.2")
+        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.4.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/cache/README.md
+++ b/Examples/cache/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com)
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys)
 
 ## Running the example
 

--- a/Examples/cache/Sources/main.swift
+++ b/Examples/cache/Sources/main.swift
@@ -1,4 +1,5 @@
 import Momento
+import Foundation
 
 func main() async {
   print("Running Momento Cache example!")
@@ -9,7 +10,7 @@ func main() async {
         creds = try CredentialProvider.fromEnvironmentVariable(envVariableName: "MOMENTO_API_KEY")
     } catch {
         print("Error establishing credential provider: \(error)")
-        return
+        exit(1)
     }
 
     let cacheClient = CacheClient(
@@ -26,6 +27,7 @@ func main() async {
         print("Successfully created the cache!")
     case .error(let err):
         print("Unable to create the cache: \(err)")
+        exit(1)
     }
 
     let listResult = await cacheClient.listCaches()
@@ -34,6 +36,7 @@ func main() async {
         print("Successfully created fetched list of caches: \(success.caches.map { $0.name })")
     case .error(let err):
         print("Unable to fetch list of caches: \(err)")
+        exit(1)
     }
 
     let setResult = await cacheClient.set(
@@ -46,6 +49,7 @@ func main() async {
         print("Successfully set item in the cache")
     case .error(let err):
         print("Unable to set item in the cache: \(err)")
+        exit(1)
     }
 
     let getResult = await cacheClient.get(
@@ -59,6 +63,7 @@ func main() async {
         print("Cache miss")
     case .error(let err):
         print("Unable to get item in the cache: \(err)")
+        exit(1)
     }
 
     let deleteResult = await cacheClient.deleteCache(cacheName: cacheName)
@@ -67,6 +72,7 @@ func main() async {
         print("Successfully deleted the cache!")
     case .error(let err):
         print("Unable to delete the cache: \(err)")
+        exit(1)
     }
 }
 

--- a/Examples/demo-chat-app/README.md
+++ b/Examples/demo-chat-app/README.md
@@ -2,14 +2,11 @@
 
 ## Prerequisites
 
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com). 
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys). 
 - A Momento Cache. You can create a cache in the [Momento Console](https://console.gomomento.com) as well.
 
 ## Running the example
 
 1. Open this directory as an Xcode project.
-2. Paste your Momento API key in the `demo-chat-app/MomentoDemoChatApp.swift` file where the `momentoApiKey` variable is expecting it.
-    ```
-    private let momentoApiKey: String = "<your Momento API key>"
-    ```
+2. Provide your Momento API key as an [environment variable](https://developer.apple.com/documentation/xcode/customizing-the-build-schemes-for-a-project#Specify-launch-arguments-and-environment-variables) with the name `MOMENTO_API_KEY`.
 3. Click Run (in the Product menu). 

--- a/Examples/demo-chat-app/demo-chat-app.xcodeproj/project.pbxproj
+++ b/Examples/demo-chat-app/demo-chat-app.xcodeproj/project.pbxproj
@@ -379,7 +379,7 @@
 			repositoryURL = "https://github.com/momentohq/client-sdk-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 0.3.2;
+				version = 0.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Examples/demo-chat-app/demo-chat-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/demo-chat-app/demo-chat-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/momentohq/client-sdk-swift",
       "state" : {
-        "revision" : "4ba910e0874c3dff48419684be5e9cf24be43150",
-        "version" : "0.3.2"
+        "revision" : "19087b69bc283727a72f552e28df5743de7584f8",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Examples/demo-chat-app/demo-chat-app.xcodeproj/xcshareddata/xcschemes/demo-chat-app.xcscheme
+++ b/Examples/demo-chat-app/demo-chat-app.xcodeproj/xcshareddata/xcschemes/demo-chat-app.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0809ED4D2B0E9CDF00EF52B2"
+               BuildableName = "demo-chat-app.app"
+               BlueprintName = "demo-chat-app"
+               ReferencedContainer = "container:demo-chat-app.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0809ED4D2B0E9CDF00EF52B2"
+            BuildableName = "demo-chat-app.app"
+            BlueprintName = "demo-chat-app"
+            ReferencedContainer = "container:demo-chat-app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "MOMENTO_API_KEY"
+            value = "eyJlbmRwb2ludCI6ImNlbGwtYWxwaGEtZGV2LnByZXByb2QuYS5tb21lbnRvaHEuY29tIiwiYXBpX2tleSI6ImV5SmhiR2NpT2lKSVV6STFOaUo5LmV5SnpkV0lpT2lKaGJtbDBZVUJ0YjIxbGJuUnZhSEV1WTI5dElpd2lkbVZ5SWpveExDSndJam9pUTBGQlBTSXNJbVY0Y0NJNk1UY3dOVGcyTXpRNE0zMC5rellHNHNScFNxQVNEUV9hNWpTb2Z0ZmQyaGFmcnZtLWM2czdHckg3cE40In0="
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0809ED4D2B0E9CDF00EF52B2"
+            BuildableName = "demo-chat-app.app"
+            BlueprintName = "demo-chat-app"
+            ReferencedContainer = "container:demo-chat-app.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/demo-chat-app/demo-chat-app/MessageStore.swift
+++ b/Examples/demo-chat-app/demo-chat-app/MessageStore.swift
@@ -23,10 +23,23 @@ public class MessageStore: ObservableObject {
                 cacheName: momentoClient.cacheName,
                 topicName: momentoClient.topicName
             )
+            // self.subscription = switch subResp {
+            //     case .subscription(let sub): sub
+            //     case .error(let err): fatalError("Unable to establish Topics subscription: \(err)")
+            // }
+            #if swift(>=5.9)
             self.subscription = switch subResp {
                 case .subscription(let sub): sub
                 case .error(let err): fatalError("Unable to establish Topics subscription: \(err)")
             }
+            #else 
+            switch subscribeResponse {
+                case .error(let err):
+                    fatalError("Unable to establish Topics subscription: \(err)")
+                case .subscription(let sub):
+                    self.subscription = sub
+            }
+            #endif
         }
         
         for try await item in self.subscription!.stream {

--- a/Examples/demo-chat-app/demo-chat-app/MessageStore.swift
+++ b/Examples/demo-chat-app/demo-chat-app/MessageStore.swift
@@ -23,10 +23,6 @@ public class MessageStore: ObservableObject {
                 cacheName: momentoClient.cacheName,
                 topicName: momentoClient.topicName
             )
-            // self.subscription = switch subResp {
-            //     case .subscription(let sub): sub
-            //     case .error(let err): fatalError("Unable to establish Topics subscription: \(err)")
-            // }
             #if swift(>=5.9)
             self.subscription = switch subResp {
                 case .subscription(let sub): sub

--- a/Examples/demo-chat-app/demo-chat-app/MessageStore.swift
+++ b/Examples/demo-chat-app/demo-chat-app/MessageStore.swift
@@ -23,33 +23,26 @@ public class MessageStore: ObservableObject {
                 cacheName: momentoClient.cacheName,
                 topicName: momentoClient.topicName
             )
-            switch subResp {
-            case .subscription(let subscription):
-                self.subscription = subscription
-                print("Successful subscription")
-            case .error(let err):
-                fatalError("Unable to establish Topics subscription: \(err)")
+            self.subscription = switch subResp {
+                case .subscription(let sub): sub
+                case .error(let err): fatalError("Unable to establish Topics subscription: \(err)")
             }
         }
         
-        do {
-            for try await item in self.subscription!.stream {
-                var value: String = ""
-                switch item {
-                case .itemText(let textItem):
-                    value = textItem.value
-                    print("Subscriber recieved text message: \(value)")
-                    messages.append(ReceivedMessage(text: value))
-                case .itemBinary(let binaryItem):
-                    value = String(decoding: binaryItem.value, as: UTF8.self)
-                    print("Subscriber recieved binary message: \(value)")
-                    messages.append(ReceivedMessage(text: value))
-                case .error(let err):
-                    print("Subscriber received error: \(err)")
-                }
+        for try await item in self.subscription!.stream {
+            var value: String = ""
+            switch item {
+            case .itemText(let textItem):
+                value = textItem.value
+                print("Subscriber recieved text message: \(value)")
+                messages.append(ReceivedMessage(text: value))
+            case .itemBinary(let binaryItem):
+                value = String(decoding: binaryItem.value, as: UTF8.self)
+                print("Subscriber recieved binary message: \(value)")
+                messages.append(ReceivedMessage(text: value))
+            case .error(let err):
+                print("Subscriber received error: \(err)")
             }
-        } catch {
-            print("Error while awaiting subscription item: \(error)")
         }
     }
 }

--- a/Examples/demo-chat-app/demo-chat-app/MomentoDemoChatApp.swift
+++ b/Examples/demo-chat-app/demo-chat-app/MomentoDemoChatApp.swift
@@ -2,18 +2,13 @@ import SwiftUI
 import Momento
 
 class Momento: ObservableObject {
-    private let momentoApiKey: String = ""
-    
     public var topicClient: TopicClientProtocol
     public let cacheName: String = "cache"
     public let topicName: String = "demo"
     
     init() {
-        if momentoApiKey.isEmpty {
-            fatalError("Missing Momento API key in app initiation")
-        }
         do {
-            let credProvider = try CredentialProvider.fromString(apiKey: self.momentoApiKey)
+            let credProvider = try CredentialProvider.fromEnvironmentVariable(envVariableName: "MOMENTO_API_KEY")
             self.topicClient = TopicClient(
                 configuration: TopicClientConfigurations.iOS.latest().withClientTimeout(timeout: 600),
                 credentialProvider: credProvider

--- a/Examples/doc-example-apis/Package.resolved
+++ b/Examples/doc-example-apis/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/momentohq/client-sdk-swift",
       "state" : {
-        "revision" : "4ba910e0874c3dff48419684be5e9cf24be43150",
-        "version" : "0.3.2"
+        "revision" : "19087b69bc283727a72f552e28df5743de7584f8",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Examples/doc-example-apis/Package.swift
+++ b/Examples/doc-example-apis/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "doc-example-apis",
     dependencies: [
-        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.3.2")
+        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.4.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/doc-example-apis/Sources/main.swift
+++ b/Examples/doc-example-apis/Sources/main.swift
@@ -135,10 +135,21 @@ func example_API_TopicPublish(topicClient: TopicClient, cacheName: String) async
 @available(macOS 10.15, iOS 13, *)
 func example_API_TopicSubscribe(topicClient: TopicClient, cacheName: String) async {
     let subscribeResponse = await topicClient.subscribe(cacheName: cacheName, topicName: "topic")
+
+    #if swift(>=5.9)
     let subscription = switch subscribeResponse {
         case .error(let err): fatalError("Error subscribing to topic: \(err)")
         case .subscription(let sub): sub
     }
+    #else 
+    let subscription: TopicSubscription
+    switch subscribeResponse {
+        case .error(let err):
+            fatalError("Error subscribing to topic: \(err)")
+        case .subscription(let sub):
+            subscription = sub
+    }
+    #endif
 
     // unsubscribe in 5 seconds
     Task {

--- a/Examples/quickstart/Package.resolved
+++ b/Examples/quickstart/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/momentohq/client-sdk-swift",
       "state" : {
-        "revision" : "4ba910e0874c3dff48419684be5e9cf24be43150",
-        "version" : "0.3.2"
+        "revision" : "19087b69bc283727a72f552e28df5743de7584f8",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Examples/quickstart/Package.swift
+++ b/Examples/quickstart/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.3.2")
+        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.4.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/quickstart/README.md
+++ b/Examples/quickstart/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com)
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys)
 
 ## Running the example
 

--- a/Examples/topics/Package.resolved
+++ b/Examples/topics/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/momentohq/client-sdk-swift",
       "state" : {
-        "revision" : "4ba910e0874c3dff48419684be5e9cf24be43150",
-        "version" : "0.3.2"
+        "revision" : "19087b69bc283727a72f552e28df5743de7584f8",
+        "version" : "0.4.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "663a85221ecf93e4b8fb1f0fdd34d4b27ae78665",
-        "version" : "1.20.0"
+        "revision" : "6ade19f0b57f5fc436dfecfced83f3c84d1095b9",
+        "version" : "1.21.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
+        "version" : "1.0.6"
       }
     },
     {

--- a/Examples/topics/Package.swift
+++ b/Examples/topics/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.3.2")
+        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.4.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/topics/README.md
+++ b/Examples/topics/README.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com). 
-- A Momento Cache named `my-cache`. You can create a cache in the [Momento Console](https://console.gomomento.com) as well.
+- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com/api-keys). 
+- A Momento Cache named `my-cache`. You can create a cache in the [Momento Console](https://console.gomomento.com/cache) as well.
 
 ## Running the example
 

--- a/Examples/topics/Sources/main.swift
+++ b/Examples/topics/Sources/main.swift
@@ -16,10 +16,20 @@ func main() async {
     let client = TopicClient(configuration: TopicClientConfigurations.iOS.latest(), credentialProvider: creds)
 
     let subscribeResponse = await client.subscribe(cacheName: cacheName, topicName: topicName)
+    #if swift(>=5.9)
     let subscription = switch subscribeResponse {
         case .error(let err): fatalError("Error subscribing to topic: \(err)")
         case .subscription(let sub): sub
     }
+    #else 
+    let subscription: TopicSubscription
+    switch subscribeResponse {
+        case .error(let err):
+            fatalError("Error subscribing to topic: \(err)")
+        case .subscription(let sub):
+            subscription = sub
+    }
+    #endif
     print("Subscribed to the topic")
 
     Task {

--- a/Examples/topics/Sources/main.swift
+++ b/Examples/topics/Sources/main.swift
@@ -16,73 +16,53 @@ func main() async {
     let client = TopicClient(configuration: TopicClientConfigurations.iOS.latest(), credentialProvider: creds)
 
     let subscribeResponse = await client.subscribe(cacheName: cacheName, topicName: topicName)
-    
-    let subscription: TopicSubscription
-    switch subscribeResponse {
-    case .error(let err):
-        print("Subscribe error: \(err)")
-        return
-    case .subscription(let sub):
-        print("Successful subscription!")
-        subscription = sub
+    let subscription = switch subscribeResponse {
+        case .error(let err): fatalError("Error subscribing to topic: \(err)")
+        case .subscription(let sub): sub
     }
+    print("Subscribed to the topic")
 
-    let receiveTask = Task {
-        do {
-            for try await item in subscription.stream {
-                var value: String = ""
-                switch item {
-                case .itemText(let textItem):
-                    value = textItem.value
-                    print("Subscriber recieved text message: \(value)")
-                case .itemBinary(let binaryItem):
-                    value = String(decoding: binaryItem.value, as: UTF8.self)
-                    print("Subscriber recieved binary message: \(value)")
-                case .error(let err):
-                    print("Subscriber received error: \(err)")
-                }
+    Task {
+        print("Publishing a message every 2 seconds")
+        let messages = ["hello", "and", "welcome", "to", "momento", "topics"]
+        for message in messages {
+            // Sleep for 2 seconds
+            try! await Task.sleep(nanoseconds: 2_000_000_000)
 
-                // we can exit the loop once we receive the last message
-                if value == "topics" {
-                    return
-                }
+            // Publish the message
+            let publishResponse = await client.publish(cacheName: cacheName, topicName: topicName, value: message)
+
+            // Check the response type (error or success?)
+            switch publishResponse {
+            case .error(let err):
+                print("Publish error: \(err)")
+                return
+            case .success(_):
+                print("Successfully published: \(message)")
             }
-        } catch {
-            print("Error while awaiting subscription item: \(error)")
-            return
         }
     }
 
-    let messages = ["hello", "welcome", "to", "momento", "topics"]
-    for message in messages {
-        // Publish the message
-        let publishResponse = await client.publish(cacheName: cacheName, topicName: topicName, value: message)
-
-        // Check the response type (error or success?)
-        switch publishResponse {
-        case .error(let err):
-            print("Publish error: \(err)")
-            return
-        case .success(_):
-            print("Successfully published: \(message)")
-        }
-    }
-    
-    // timeout in 10 seconds
-    let timeoutTask = Task {
+    // Unsubscribe to stop looping over subscription in 10 seconds
+    Task {
         try await Task.sleep(nanoseconds: 10_000_000_000)
-        receiveTask.cancel()
+        print("Unsubscribing from topic")
+        subscription.unsubscribe()
     }
 
-    // set up safeguard mechanism to stop the example if not all
-    // messages are received within 10 seconds
-    await withTaskCancellationHandler {
-        await receiveTask.value
-        timeoutTask.cancel()
-        return
-    } onCancel: {
-        receiveTask.cancel()
-        timeoutTask.cancel()
+    // Receive messages from the subscription as they arrive
+    for try await item in subscription.stream {
+        var value: String = ""
+        switch item {
+        case .itemText(let textItem):
+            value = textItem.value
+            print("Subscriber recieved text message: \(value)")
+        case .itemBinary(let binaryItem):
+            value = String(decoding: binaryItem.value, as: UTF8.self)
+            print("Subscriber recieved binary message: \(value)")
+        case .error(let err):
+            print("Subscriber received error: \(err)")
+        }
     }
 
     client.close()

--- a/README.template.md
+++ b/README.template.md
@@ -31,7 +31,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.3.2")
+        .package(url: "https://github.com/momentohq/client-sdk-swift", exact: "0.4.0")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Addresses the last two tasks of https://github.com/momentohq/dev-eco-issue-tracker/issues/604 

- Updates all examples to use the latest release (0.4.0)
- Subscribe examples now use switch expressions to assign subscriptions directly (if using >= Swift 5.9)
- Showed how to use `unsubscribe` in the topics example and in the docs example
- For the examples that are run in CI, `exit(1)` whenever an error occurs instead of simply printing errors (#109)
- Runs the cache example in CI instead of just building it
- iOS sample app uses `MOMENTO_API_KEY` env var instead of hardcoded string
- Updated readme template to use v0.4.0
- Updated links in readmes to point to specifically the api-keys page or cache page as appropriate
