### PR TITLE
feat: add close method to CacheClient

### DIFF
--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -1024,10 +1024,8 @@ public class CacheClient: CacheClientProtocol {
       switch response {
       case .error(let err):
          print("Error: \(err)")
-      case .alreadyExists(_):
-         print("Cache already exists")
-      case .success(_):
-         print("Success")
+      case .success(let s):
+         print("Success: \(s.listLength)")
       }
      ```
      */
@@ -1331,5 +1329,10 @@ public class CacheClient: CacheClientProtocol {
             endIndex: endIndex,
             ttl: ttl
         )
+    }
+
+    public func close() {
+        self.controlClient.close()
+        self.dataClient.close()
     }
 }

--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -1331,6 +1331,10 @@ public class CacheClient: CacheClientProtocol {
         )
     }
 
+    /** Close the client and free up all associated resources.
+     
+     NOTE: the client object will not be usable after calling this method.
+    **/
     public func close() {
         self.controlClient.close()
         self.dataClient.close()

--- a/Sources/Momento/internal/ControlClient.swift
+++ b/Sources/Momento/internal/ControlClient.swift
@@ -10,6 +10,8 @@ protocol ControlClientProtocol {
     func deleteCache(cacheName: String) async -> DeleteCacheResponse
     
     func listCaches() async -> ListCachesResponse
+
+    func close()
 }
 
 @available(macOS 10.15, iOS 13, *)
@@ -140,6 +142,14 @@ class ControlClient: ControlClientProtocol {
             return ListCachesResponse.error(
                 ListCachesError(error: UnknownError(message: "unknown cache create error \(error)"))
             )
+        }
+    }
+
+    func close() {
+        do {
+            try self.grpcChannel.close().wait()
+        } catch {
+            self.logger.error("Failed to close cache control client GRPC channel: \(error)")
         }
     }
 }

--- a/Sources/Momento/internal/DataClient.swift
+++ b/Sources/Momento/internal/DataClient.swift
@@ -84,6 +84,8 @@ protocol DataClientProtocol {
         endIndex: Int?,
         ttl: CollectionTtl?
     ) async -> ListRetainResponse
+
+    func close()
 }
 
 @available(macOS 10.15, iOS 13, *)
@@ -693,6 +695,14 @@ class DataClient: DataClientProtocol {
             return ListRetainResponse.error(
                 ListRetainError(error: UnknownError(message: "unknown list retain error \(error)"))
             )
+        }
+    }
+
+    func close() {
+        do {
+            try self.grpcChannel.close().wait()
+        } catch {
+            self.logger.error("Failed to close cache data client GRPC channel: \(error)")
         }
     }
 }


### PR DESCRIPTION
Adds a `close` method to the CacheClient. I think this will be needed to prevent an ever-growing number of grpc connections in the ios moderated chat demo whenever the disposable token and the cache and topic clients need to be refreshed.

Also fixed the docstring mentioned in https://github.com/momentohq/client-sdk-swift/issues/129