### PR TITLE
fix: pass errors as innerException and don't auto-resubscribe when connection becomes unavailable

### DIFF
--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -326,7 +326,7 @@ public class CacheClient: CacheClientProtocol {
             return CreateCacheResponse.error(CreateCacheError(error: err))
         } catch {
             return CreateCacheResponse.error(
-                CreateCacheError(error: UnknownError(message: "unexpected error: \(error)"))
+                CreateCacheError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.controlClient.createCache(cacheName: cacheName)
@@ -354,7 +354,7 @@ public class CacheClient: CacheClientProtocol {
             return DeleteCacheResponse.error(DeleteCacheError(error: err))
         } catch {
             return DeleteCacheResponse.error(
-                DeleteCacheError(error: UnknownError(message: "unexpected error: \(error)"))
+                DeleteCacheError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.controlClient.deleteCache(cacheName: cacheName)
@@ -431,9 +431,9 @@ public class CacheClient: CacheClientProtocol {
         } catch let err as SdkError {
             return GetResponse.error(GetError(error: err))
         } catch {
-            return GetResponse.error(GetError(error: UnknownError(
-                message: "unexpected error: \(error)")
-            ))
+            return GetResponse.error(
+                GetError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+            )
         }
         return await self.dataClient.get(cacheName: cacheName, key: key)
     }
@@ -583,9 +583,9 @@ public class CacheClient: CacheClientProtocol {
         } catch let err as SdkError {
             return SetResponse.error(SetError(error: err))
         } catch {
-            return SetResponse.error(SetError(error: UnknownError(
-                message: "unexpected error: \(error)")
-            ))
+            return SetResponse.error(
+                SetError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+            )
         }
         return await self.dataClient.set(
             cacheName: cacheName,
@@ -644,9 +644,9 @@ public class CacheClient: CacheClientProtocol {
         } catch let err as SdkError {
             return DeleteResponse.error(DeleteError(error: err))
         } catch {
-            return DeleteResponse.error(DeleteError(error: UnknownError(
-                message: "unexpected error: \(error)")
-            ))
+            return DeleteResponse.error(
+                DeleteError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+            )
         }
         return await self.dataClient.delete(cacheName: cacheName, key: key)
     }
@@ -740,9 +740,7 @@ public class CacheClient: CacheClientProtocol {
             return ListConcatenateBackResponse.error(ListConcatenateBackError(error: err))
         } catch {
             return ListConcatenateBackResponse.error(
-                ListConcatenateBackError(error: UnknownError(
-                    message: "unexpected error: \(error)")
-                )
+                ListConcatenateBackError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listConcatenateBack(
@@ -843,7 +841,7 @@ public class CacheClient: CacheClientProtocol {
             return ListConcatenateFrontResponse.error(ListConcatenateFrontError(error: err))
         } catch {
             return ListConcatenateFrontResponse.error(
-                ListConcatenateFrontError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListConcatenateFrontError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listConcatenateFront(
@@ -890,7 +888,7 @@ public class CacheClient: CacheClientProtocol {
             return ListFetchResponse.error(ListFetchError(error: err))
         } catch {
             return ListFetchResponse.error(
-                ListFetchError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListFetchError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listFetch(
@@ -931,7 +929,7 @@ public class CacheClient: CacheClientProtocol {
             return ListLengthResponse.error(ListLengthError(error: err))
         } catch {
             return ListLengthResponse.error(
-                ListLengthError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListLengthError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listLength(cacheName: cacheName, listName: listName)
@@ -967,7 +965,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPopBackResponse.error(ListPopBackError(error: err))
         } catch {
             return ListPopBackResponse.error(
-                ListPopBackError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListPopBackError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listPopBack(cacheName: cacheName, listName: listName)
@@ -1003,7 +1001,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPopFrontResponse.error(ListPopFrontError(error: err))
         } catch {
             return ListPopFrontResponse.error(
-                ListPopFrontError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListPopFrontError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listPopFront(cacheName: cacheName, listName: listName)
@@ -1097,7 +1095,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPushBackResponse.error(ListPushBackError(error: err))
         } catch {
             return ListPushBackResponse.error(
-                ListPushBackError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListPushBackError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listPushBack(
@@ -1197,7 +1195,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPushFrontResponse.error(ListPushFrontError(error: err))
         } catch {
             return ListPushFrontResponse.error(
-                ListPushFrontError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListPushFrontError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listPushFront(
@@ -1273,7 +1271,7 @@ public class CacheClient: CacheClientProtocol {
             return ListRemoveValueResponse.error(ListRemoveValueError(error: err))
         } catch {
             return ListRemoveValueResponse.error(
-                ListRemoveValueError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListRemoveValueError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listRemoveValue(
@@ -1319,7 +1317,7 @@ public class CacheClient: CacheClientProtocol {
             return ListRetainResponse.error(ListRetainError(error: err))
         } catch {
             return ListRetainResponse.error(
-                ListRetainError(error: UnknownError(message: "unexpected error: \(error)"))
+                ListRetainError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         return await self.dataClient.listRetain(

--- a/Sources/Momento/CacheClient.swift
+++ b/Sources/Momento/CacheClient.swift
@@ -326,7 +326,7 @@ public class CacheClient: CacheClientProtocol {
             return CreateCacheResponse.error(CreateCacheError(error: err))
         } catch {
             return CreateCacheResponse.error(
-                CreateCacheError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                CreateCacheError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.controlClient.createCache(cacheName: cacheName)
@@ -432,7 +432,7 @@ public class CacheClient: CacheClientProtocol {
             return GetResponse.error(GetError(error: err))
         } catch {
             return GetResponse.error(
-                GetError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                GetError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.get(cacheName: cacheName, key: key)
@@ -584,7 +584,7 @@ public class CacheClient: CacheClientProtocol {
             return SetResponse.error(SetError(error: err))
         } catch {
             return SetResponse.error(
-                SetError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                SetError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.set(
@@ -645,7 +645,7 @@ public class CacheClient: CacheClientProtocol {
             return DeleteResponse.error(DeleteError(error: err))
         } catch {
             return DeleteResponse.error(
-                DeleteError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                DeleteError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.delete(cacheName: cacheName, key: key)
@@ -740,7 +740,7 @@ public class CacheClient: CacheClientProtocol {
             return ListConcatenateBackResponse.error(ListConcatenateBackError(error: err))
         } catch {
             return ListConcatenateBackResponse.error(
-                ListConcatenateBackError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListConcatenateBackError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listConcatenateBack(
@@ -841,7 +841,7 @@ public class CacheClient: CacheClientProtocol {
             return ListConcatenateFrontResponse.error(ListConcatenateFrontError(error: err))
         } catch {
             return ListConcatenateFrontResponse.error(
-                ListConcatenateFrontError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListConcatenateFrontError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listConcatenateFront(
@@ -888,7 +888,7 @@ public class CacheClient: CacheClientProtocol {
             return ListFetchResponse.error(ListFetchError(error: err))
         } catch {
             return ListFetchResponse.error(
-                ListFetchError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListFetchError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listFetch(
@@ -929,7 +929,7 @@ public class CacheClient: CacheClientProtocol {
             return ListLengthResponse.error(ListLengthError(error: err))
         } catch {
             return ListLengthResponse.error(
-                ListLengthError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListLengthError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listLength(cacheName: cacheName, listName: listName)
@@ -965,7 +965,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPopBackResponse.error(ListPopBackError(error: err))
         } catch {
             return ListPopBackResponse.error(
-                ListPopBackError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListPopBackError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listPopBack(cacheName: cacheName, listName: listName)
@@ -1001,7 +1001,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPopFrontResponse.error(ListPopFrontError(error: err))
         } catch {
             return ListPopFrontResponse.error(
-                ListPopFrontError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListPopFrontError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listPopFront(cacheName: cacheName, listName: listName)
@@ -1095,7 +1095,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPushBackResponse.error(ListPushBackError(error: err))
         } catch {
             return ListPushBackResponse.error(
-                ListPushBackError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListPushBackError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listPushBack(
@@ -1195,7 +1195,7 @@ public class CacheClient: CacheClientProtocol {
             return ListPushFrontResponse.error(ListPushFrontError(error: err))
         } catch {
             return ListPushFrontResponse.error(
-                ListPushFrontError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListPushFrontError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listPushFront(
@@ -1271,7 +1271,7 @@ public class CacheClient: CacheClientProtocol {
             return ListRemoveValueResponse.error(ListRemoveValueError(error: err))
         } catch {
             return ListRemoveValueResponse.error(
-                ListRemoveValueError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListRemoveValueError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listRemoveValue(
@@ -1317,7 +1317,7 @@ public class CacheClient: CacheClientProtocol {
             return ListRetainResponse.error(ListRetainError(error: err))
         } catch {
             return ListRetainResponse.error(
-                ListRetainError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                ListRetainError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         return await self.dataClient.listRetain(

--- a/Sources/Momento/TopicClient.swift
+++ b/Sources/Momento/TopicClient.swift
@@ -119,7 +119,7 @@ public class TopicClient: TopicClientProtocol {
             return TopicPublishResponse.error(TopicPublishError(error: err))
         } catch {
             return TopicPublishResponse.error(
-                TopicPublishError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                TopicPublishError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         
@@ -134,7 +134,7 @@ public class TopicClient: TopicClientProtocol {
             return TopicPublishResponse.error(
                 TopicPublishError(
                     error: UnknownError(
-                        message: "Unknown error from publish",
+                        message: "Unknown error from publish: '\(error)'",
                         innerException: error
                     )
                 )
@@ -167,7 +167,7 @@ public class TopicClient: TopicClientProtocol {
             return TopicSubscribeResponse.error(TopicSubscribeError(error: err))
         } catch {
             return TopicSubscribeResponse.error(
-                TopicSubscribeError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
+                TopicSubscribeError(error: UnknownError(message: "unexpected error: '\(error)'", innerException: error))
             )
         }
         
@@ -183,7 +183,7 @@ public class TopicClient: TopicClientProtocol {
         } catch {
             return TopicSubscribeResponse.error(TopicSubscribeError(
                 error: UnknownError(
-                    message: "Unknown error from subscribe",
+                    message: "Unknown error from subscribe: '\(error)'",
                     innerException: error
                 )
             ))

--- a/Sources/Momento/TopicClient.swift
+++ b/Sources/Momento/TopicClient.swift
@@ -119,7 +119,7 @@ public class TopicClient: TopicClientProtocol {
             return TopicPublishResponse.error(TopicPublishError(error: err))
         } catch {
             return TopicPublishResponse.error(
-                TopicPublishError(error: UnknownError(message: "unexpected error: \(error)"))
+                TopicPublishError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         
@@ -167,7 +167,7 @@ public class TopicClient: TopicClientProtocol {
             return TopicSubscribeResponse.error(TopicSubscribeError(error: err))
         } catch {
             return TopicSubscribeResponse.error(
-                TopicSubscribeError(error: UnknownError(message: "unexpected error: \(error)"))
+                TopicSubscribeError(error: UnknownError(message: "unexpected error: \(error)", innerException: error))
             )
         }
         

--- a/Sources/Momento/errors/Errors.swift
+++ b/Sources/Momento/errors/Errors.swift
@@ -302,6 +302,6 @@ internal func grpcStatusToSdkError(grpcStatus: GRPCStatus) -> SdkError {
     case .unknown:
         return UnknownServiceError(message: message, innerException: grpcStatus)
     default:
-        return UnknownError(message: "Unknown error")
+        return UnknownError(message: "Unknown error", innerException: grpcStatus)
     }
 }

--- a/Sources/Momento/internal/ControlClient.swift
+++ b/Sources/Momento/internal/ControlClient.swift
@@ -91,7 +91,7 @@ class ControlClient: ControlClientProtocol {
             )
         } catch {
             return CreateCacheResponse.error(
-                CreateCacheError(error: UnknownError(message: "unknown cache create error \(error)"))
+                CreateCacheError(error: UnknownError(message: "unknown cache create error: '\(error)'", innerException: error))
             )
         }
     }
@@ -116,7 +116,7 @@ class ControlClient: ControlClientProtocol {
             )
         } catch {
             return DeleteCacheResponse.error(
-                DeleteCacheError(error: UnknownError(message: "unknown cache create error \(error)"))
+                DeleteCacheError(error: UnknownError(message: "unknown cache delete error: '\(error)'", innerException: error))
             )
         }
     }
@@ -140,7 +140,7 @@ class ControlClient: ControlClientProtocol {
             )
         } catch {
             return ListCachesResponse.error(
-                ListCachesError(error: UnknownError(message: "unknown cache create error \(error)"))
+                ListCachesError(error: UnknownError(message: "unknown list caches error: '\(error)'", innerException: error))
             )
         }
     }

--- a/Sources/Momento/internal/ControlClient.swift
+++ b/Sources/Momento/internal/ControlClient.swift
@@ -149,7 +149,7 @@ class ControlClient: ControlClientProtocol {
         do {
             try self.grpcChannel.close().wait()
         } catch {
-            self.logger.error("Failed to close cache control client GRPC channel: \(error)")
+            self.logger.error("Failed to close cache control client GRPC channel: '\(error)'")
         }
     }
 }

--- a/Sources/Momento/internal/DataClient.swift
+++ b/Sources/Momento/internal/DataClient.swift
@@ -176,7 +176,7 @@ class DataClient: DataClientProtocol {
                 return GetResponse.miss(GetMiss())
             } else {
                 return GetResponse.error(GetError(
-                    error: UnknownError(message: "unknown cache get error \(result)")
+                    error: UnknownError(message: "unknown cache get result: '\(result)'")
                 ))
             }
         } catch let err as GRPCStatus {
@@ -187,7 +187,7 @@ class DataClient: DataClientProtocol {
             ))
         } catch {
             return GetResponse.error(GetError(
-                error: UnknownError(message: "unknown cache get error \(error)")
+                error: UnknownError(message: "unknown cache get error: '\(error)'", innerException: error)
             ))
         }
     }
@@ -225,7 +225,7 @@ class DataClient: DataClientProtocol {
             ))
         } catch {
             return SetResponse.error(SetError(
-                error: UnknownError(message: "unknown cache set error \(error)")
+                error: UnknownError(message: "unknown cache set error: '\(error)'", innerException: error)
             ))
         }
     }
@@ -254,7 +254,7 @@ class DataClient: DataClientProtocol {
             ))
         } catch {
             return DeleteResponse.error(DeleteError(
-                error: UnknownError(message: "unknown cache set error \(error)")
+                error: UnknownError(message: "unknown cache set error: '\(error)'", innerException: error)
             ))
         }
     }
@@ -298,7 +298,7 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListConcatenateBackResponse.error(ListConcatenateBackError(
-                error: UnknownError(message: "unknown list concatenate back error \(error)"))
+                error: UnknownError(message: "unknown list concatenate back error: '\(error)'", innerException: error))
             )
         }
     }
@@ -340,7 +340,9 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListConcatenateFrontResponse.error(
-                ListConcatenateFrontError(error: UnknownError(message: "unknown list concatenate front error \(error)"))
+                ListConcatenateFrontError(
+                    error: UnknownError(message: "unknown list concatenate front error: '\(error)'", innerException: error)
+                )
             )
         }
     }
@@ -396,7 +398,7 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListFetchResponse.error(
-                ListFetchError(error: UnknownError(message: "unknown list fetch error \(error)"))
+                ListFetchError(error: UnknownError(message: "unknown list fetch error: '\(error)'", innerException: error))
             )
         }
     }
@@ -427,7 +429,7 @@ class DataClient: DataClientProtocol {
                 return ListLengthResponse.miss(ListLengthMiss())
             default:
                 return ListLengthResponse.error(
-                    ListLengthError(error: UnknownError(message: "unknown list length error \(result)"))
+                    ListLengthError(error: UnknownError(message: "unknown list length result: \(result)"))
                 )
             }
         } catch let err as GRPCStatus {
@@ -438,7 +440,7 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListLengthResponse.error(
-                ListLengthError(error: UnknownError(message: "unknown list length error \(error)"))
+                ListLengthError(error: UnknownError(message: "unknown list length error: '\(error)'", innerException: error))
             )
         }
     }
@@ -469,7 +471,7 @@ class DataClient: DataClientProtocol {
                 return ListPopBackResponse.miss(ListPopBackMiss())
             default:
                 return ListPopBackResponse.error(
-                    ListPopBackError(error: UnknownError(message: "unknown list pop back error \(result)"))
+                    ListPopBackError(error: UnknownError(message: "unknown list pop back result: \(result)"))
                 )
             }
         } catch let err as GRPCStatus {
@@ -480,7 +482,9 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListPopBackResponse.error(
-                ListPopBackError(error: UnknownError(message: "unknown list pop back error \(error)"))
+                ListPopBackError(
+                    error: UnknownError(message: "unknown list pop back error: '\(error)'", innerException: error)
+                )
             )
         }
     }
@@ -511,7 +515,7 @@ class DataClient: DataClientProtocol {
                 return ListPopFrontResponse.miss(ListPopFrontMiss())
             default:
                 return ListPopFrontResponse.error(
-                    ListPopFrontError(error: UnknownError(message: "unknown list pop front error \(result)"))
+                    ListPopFrontError(error: UnknownError(message: "unknown list pop front result: \(result)"))
                 )
             }
         } catch let err as GRPCStatus {
@@ -522,7 +526,9 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListPopFrontResponse.error(
-                ListPopFrontError(error: UnknownError(message: "unknown list pop front error \(error)"))
+                ListPopFrontError(
+                    error: UnknownError(message: "unknown list pop front error: '\(error)'", innerException: error)
+                )
             )
         }
     }
@@ -564,7 +570,9 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListPushBackResponse.error(
-                ListPushBackError(error: UnknownError(message: "unknown list push back error \(error)"))
+                ListPushBackError(
+                    error: UnknownError(message: "unknown list push back error: '\(error)'", innerException: error)
+                )
             )
         }
     }
@@ -606,7 +614,9 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListPushFrontResponse.error(
-                ListPushFrontError(error: UnknownError(message: "unknown list push front error \(error)"))
+                ListPushFrontError(
+                    error: UnknownError(message: "unknown list push front error: '\(error)'", innerException: error)
+                )
             )
         }
     }
@@ -641,7 +651,9 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListRemoveValueResponse.error(
-                ListRemoveValueError(error: UnknownError(message: "unknown list remove value error \(error)"))
+                ListRemoveValueError(
+                    error: UnknownError(message: "unknown list remove value error: '\(error)'", innerException: error)
+                )
             )
         }
     }
@@ -693,7 +705,7 @@ class DataClient: DataClientProtocol {
             )
         } catch {
             return ListRetainResponse.error(
-                ListRetainError(error: UnknownError(message: "unknown list retain error \(error)"))
+                ListRetainError(error: UnknownError(message: "unknown list retain error: '\(error)'", innerException: error))
             )
         }
     }

--- a/Sources/Momento/internal/DataClient.swift
+++ b/Sources/Momento/internal/DataClient.swift
@@ -387,7 +387,7 @@ class DataClient: DataClientProtocol {
                 return ListFetchResponse.miss(ListFetchMiss())
             default:
                 return ListFetchResponse.error(
-                    ListFetchError(error: UnknownError(message: "unknown list fetch error \(result)"))
+                    ListFetchError(error: UnknownError(message: "unknown list fetch result: \(result)"))
                 )
             }
         } catch let err as GRPCStatus {

--- a/Sources/Momento/internal/PubsubClient.swift
+++ b/Sources/Momento/internal/PubsubClient.swift
@@ -86,7 +86,7 @@ class PubsubClient: PubsubClientProtocol {
             return TopicPublishResponse.error(TopicPublishError(error: grpcStatusToSdkError(grpcStatus: err.makeGRPCStatus())))
         } catch {
             return TopicPublishResponse.error(
-                TopicPublishError(error: UnknownError(message: "unknown publish error \(error)"))
+                TopicPublishError(error: UnknownError(message: "unknown publish error: '\(error)'", innerException: error))
             )
         }
     }

--- a/Sources/Momento/internal/PubsubClient.swift
+++ b/Sources/Momento/internal/PubsubClient.swift
@@ -133,7 +133,7 @@ class PubsubClient: PubsubClientProtocol {
             return TopicSubscribeResponse.error(TopicSubscribeError(error: grpcStatusToSdkError(grpcStatus: err.makeGRPCStatus())))
         } catch {
             return TopicSubscribeResponse.error(
-                TopicSubscribeError(error: UnknownError(message: "unknown subscribe error \(error)"))
+                TopicSubscribeError(error: UnknownError(message: "unknown subscribe error: '\(error)'", innerException: error))
             )
         }
     }

--- a/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
@@ -62,7 +62,7 @@ public class TopicSubscription {
                     // If the topic client is closed but the subscription is still open, we'll
                     // receive a "shutdown" error that gets converted into an "unavailable"
                     // GRPCStatus object. See: https://github.com/grpc/grpc-swift/blob/53e2739912b0d3090cfa6a8345fcadbe6fe2ba1a/Sources/GRPC/ConnectionPool/ConnectionPool.swift#L1025
-                    print("Connection was shutdown, not resubscribing")
+                    self.logger.debug("Connection was shutdown, not resubscribing")
                     return nil
                 } else {
                     self.logger.debug("Caught GRPCStatus \(err), attempting to resubscribe")

--- a/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
+++ b/Sources/Momento/messages/responses/topics/TopicSubscribe.swift
@@ -58,6 +58,12 @@ public class TopicSubscription {
                 } else if (err.code == .resourceExhausted) {
                     self.logger.debug("Too many subscribers, not resubscribing")
                     return nil
+                } else if (err.code == .unavailable) {
+                    // If the topic client is closed but the subscription is still open, we'll
+                    // receive a "shutdown" error that gets converted into an "unavailable"
+                    // GRPCStatus object. See: https://github.com/grpc/grpc-swift/blob/53e2739912b0d3090cfa6a8345fcadbe6fe2ba1a/Sources/GRPC/ConnectionPool/ConnectionPool.swift#L1025
+                    print("Connection was shutdown, not resubscribing")
+                    return nil
                 } else {
                     self.logger.debug("Caught GRPCStatus \(err), attempting to resubscribe")
                     await self.attemptResubscribe()


### PR DESCRIPTION
`innerException` already exists on the `SdkError` object, just forgot to pass it in in many places where we create UnknownError objects. Should be easier to tell the distinction between our error message and the received error message as well.