### PR TITLE
fix: use @available tag instead of if statement in processError

### DIFF
--- a/Sources/Momento/errors/Errors.swift
+++ b/Sources/Momento/errors/Errors.swift
@@ -363,18 +363,15 @@ func grpcStatusToSdkError(grpcStatus: GRPCStatus, metadata: HPACKHeaders? = nil)
     }
 }
 
+@available(macOS 10.15, iOS 13, *)
 func processError<Request: Message & Sendable, Response: Message & Sendable>(
     err: GRPCStatus,
     call: UnaryCall<Request, Response>
 ) async -> SdkError {
-    if #available(macOS 10.15, *) {
-        do {
-            let trailers = try await call.trailingMetadata.get()
-            return grpcStatusToSdkError(grpcStatus: err, metadata: trailers)
-        } catch {
-            return grpcStatusToSdkError(grpcStatus: err)
-        }
-    } else {
+    do {
+        let trailers = try await call.trailingMetadata.get()
+        return grpcStatusToSdkError(grpcStatus: err, metadata: trailers)
+    } catch {
         return grpcStatusToSdkError(grpcStatus: err)
     }
 }


### PR DESCRIPTION
Was running into `'get()' is only available in iOS 13 or newer` error while checking the moderated chat demo with the latest Swift package version.

Realized the `if #available` check was missing iOS 13, and also it's inconsistent with our usage of `@available` everywhere else in the SDK. Changed to `@available(macOS 10.15, iOS 13, *)` encompassing the entire function instead.
