### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -32,5 +32,4 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       auth-token: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      github-token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
       api-key-v2: ${{ secrets.ALPHA_API_KEY_V2 }}

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -7,10 +7,17 @@ jobs:
   readme:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate README
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v2
@@ -28,7 +35,6 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       auth-token: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      github-token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
       api-key-v2: ${{ secrets.ALPHA_API_KEY_V2 }}
 
   publish:
@@ -36,11 +42,18 @@ jobs:
     needs: test
 
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - uses: google-github-actions/release-please-action@v3
         name: Release Please
         id: release
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           release-type: simple
           package-name: client-sdk-swift
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
       auth-token:
         description: "v1 api key used for integration tests"
         required: true
-      github-token:
-        description: "Token for running Github actions"
-        required: true
       api-key-v2:
         description: "v2 api key used for integration tests"
         required: true
@@ -28,8 +25,6 @@ jobs:
 
       - name: Setup repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.github-token }}
 
       - name: Build momento package
         run: swift build


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.
- `actions/checkout` steps that only read this repo had their `token:` dropped;
  checkout already defaults to `GITHUB_TOKEN`.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
